### PR TITLE
[FHIR-APIs] Refactor search operation in `questionnaire-response-service`

### DIFF
--- a/fhir-apis/questionnaire-response-service/Dependencies.toml
+++ b/fhir-apis/questionnaire-response-service/Dependencies.toml
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.12.8"
+version = "2.12.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},


### PR DESCRIPTION
## Purpose
To refactor the existing search operation in questionnaire-response-service to handle the `authored` search parameter which is a date. 

According to the spec, the 'authored' is a date. Therefore, the search operation should be treated as a `date` not `dateTime`
[Spec](https://hl7.org/fhir/questionnaireresponse-search.html#QuestionnaireResponse-authored)