### PR TITLE
[FHIR-APIs] Refactor auth configuration for claim-repository-service

### DIFF
--- a/fhir-apis/claim-response-service/.choreo/component.yaml
+++ b/fhir-apis/claim-response-service/.choreo/component.yaml
@@ -12,5 +12,5 @@ endpoints:
     schemaFilePath: oas/ClaimResponse.yaml
 dependencies:
     connectionReferences:
-      - name: claim_response_service_repository_connection
-        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC
+    - name: claim_response_service_repository_connection
+      resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-response-service/.choreo/component.yaml
+++ b/fhir-apis/claim-response-service/.choreo/component.yaml
@@ -10,3 +10,7 @@ endpoints:
       - Project
       - Public
     schemaFilePath: oas/ClaimResponse.yaml
+dependencies:
+    connectionReferences:
+      - name: claim_response_service_repository_connection
+        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-response-service/service.bal
+++ b/fhir-apis/claim-response-service/service.bal
@@ -25,8 +25,12 @@ import ballerinax/health.fhir.r4.davincipas;
 # public type ClaimResponse r4:ClaimResponse|<other_ClaimResponse_Profile>;
 public type ClaimResponse davincipas:PASClaimResponse;
 
-# To access the claim repository service, the client needs to be initialized with the endpoint URL.
-configurable string claimRepositoryServiceUrl = ?;
+# Configurations for the claim repository service.
+configurable string serviceURL = ?;
+configurable string consumerKey = ?;
+configurable string consumerSecret = ?;
+configurable string tokenURL = ?;
+configurable string choreoApiKey = ?;
 
 # initialize source system endpoint here
 

--- a/fhir-apis/claim-service/.choreo/component.yaml
+++ b/fhir-apis/claim-service/.choreo/component.yaml
@@ -10,3 +10,7 @@ endpoints:
       - Project
       - Public
     schemaFilePath: oas/Claim.yaml
+dependencies:
+    connectionReferences:
+      - name: claim_service_repo_connection
+        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-service/.choreo/component.yaml
+++ b/fhir-apis/claim-service/.choreo/component.yaml
@@ -12,5 +12,5 @@ endpoints:
     schemaFilePath: oas/Claim.yaml
 dependencies:
     connectionReferences:
-      - name: claim_service_repo_connection
-        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC
+    - name: claim_service_repo_connection
+      resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-service/service.bal
+++ b/fhir-apis/claim-service/service.bal
@@ -25,8 +25,12 @@ import ballerinax/health.fhir.r4.davincipas;
 # public type Claim r4:Claim|<other_Claim_Profile>;
 public type Claim davincipas:PASClaim;
 
-# To access the claim repository service, the client needs to be initialized with the endpoint URL.
-configurable string claimRepositoryServiceUrl = ?;
+# Configurations for the claim repository service.
+configurable string serviceURL = ?;
+configurable string consumerKey = ?;
+configurable string consumerSecret = ?;
+configurable string tokenURL = ?;
+configurable string choreoApiKey = ?;
 
 # initialize source system endpoint here
 

--- a/fhir-apis/claim-submission-service/.choreo/component.yaml
+++ b/fhir-apis/claim-submission-service/.choreo/component.yaml
@@ -12,5 +12,5 @@ endpoints:
     schemaFilePath: oas/Parameters.yaml
 dependencies:
     connectionReferences:
-      - name: claim_submission_service_repository_connection
-        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC
+    - name: claim_submission_service_repository_connection
+      resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-submission-service/.choreo/component.yaml
+++ b/fhir-apis/claim-submission-service/.choreo/component.yaml
@@ -10,3 +10,7 @@ endpoints:
       - Project
       - Public
     schemaFilePath: oas/Parameters.yaml
+dependencies:
+    connectionReferences:
+      - name: claim_submission_service_repository_connection
+        resourceRef: service:/cms-0057-f/claim-repository-service/v1/176f4/PUBLIC

--- a/fhir-apis/claim-submission-service/service.bal
+++ b/fhir-apis/claim-submission-service/service.bal
@@ -25,8 +25,12 @@ import ballerinax/health.fhir.r4.international401;
 # public type Parameters r4:Parameters|<other_Parameters_Profile>;
 public type Parameters international401:Parameters;
 
-# To access the claim repository service, the client needs to be initialized with the endpoint URL.
-configurable string claimRepositoryServiceUrl = ?;
+# Configurations for the claim repository service.
+configurable string serviceURL = ?;
+configurable string consumerKey = ?;
+configurable string consumerSecret = ?;
+configurable string tokenURL = ?;
+configurable string choreoApiKey = ?;
 
 # initialize source system endpoint here
 


### PR DESCRIPTION
## Purpose

This pull request introduces enhancements to the FHIR API services (`claim-response-service`, `claim-service`, and `claim-submission-service`) by implementing authentication for HTTP clients, adding dependency references, and updating configurations. These changes improve security, maintainability, and integration with the claim repository service.

Refactor the auth configurations for HHTP Client which used to connect claim-repository-service from following services
- Claim
- Claim Response
- Claim Submission