### PR TITLE
Add get by id endpoing for pdex requests

### DIFF
--- a/bulk-export-client/Config.toml
+++ b/bulk-export-client/Config.toml
@@ -1,20 +1,3 @@
-[sourceServerConfigs.test1]
-authEnabled = false
-baseUrl = "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwidGx0IjoxNSwibSI6MSwiZGVsIjowLCJzZWN1cmUiOjB9/fhir"
-tokenUrl = "https://auth-server1.example.com/oauth2/token"
-clientId = "bulk-export-client-id-1"
-clientSecret = "bulk-export-client-secret-1"
-scopes = ["system/Patient.read", "system/*.read"]
-fileServerUrl = "https://files-server1.example.com"
-
-[sourceServerConfigs.test2]
-authEnabled = false
-baseUrl = "https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwidGx0IjoxNSwibSI6MSwiZGVsIjowLCJzZWN1cmUiOjB9/fhir"
-tokenUrl = "https://auth-server2.example.com/oauth2/token"
-clientId = "bulk-export-client-id-2"
-clientSecret = "bulk-export-client-secret-2"
-scopes = ["system/Patient.read"]
-
 [clientServiceConfig]
 baseUrl = "http://localhost:8091"
 authEnabled = false

--- a/bulk-export-client/Dependencies.toml
+++ b/bulk-export-client/Dependencies.toml
@@ -388,6 +388,9 @@ version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "url", moduleName = "url"}
+]
 
 [[package]]
 org = "ballerina"
@@ -550,6 +553,7 @@ dependencies = [
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "url"},
 	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"},
 	{org = "ballerinax", name = "health.fhir.r4"},

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -68,6 +68,19 @@ isolated service /pdex on bulkExportListener {
         };
     }
 
+    // Resource function to retrieve a specific payer data exchange request.
+    //
+    // @param requestId - The ID of the request to retrieve.
+    // @return The payer data exchange request details.
+    isolated resource function get 'pdex\-data\-requests/[string requestId]() returns json|error {
+        PayerDataExchangeRequest|error request = getPayerDataExchangeRequest(requestId);
+        if request is error {
+            log:printError("Error occurred while fetching payer data exchange request", request);
+            return error("Request ID not found");
+        }
+        return request;
+    }
+
     // Resource function to update payer data exchange request status.
     //
     // @param requestId - The ID of the request to update.

--- a/bulk-export-client/service.bal
+++ b/bulk-export-client/service.bal
@@ -17,7 +17,6 @@ import ballerina/log;
 import ballerina/mime;
 import ballerina/uuid;
 
-configurable map<BulkExportServerConfig> & readonly sourceServerConfigs = ?;
 configurable BulkExportClientConfig & readonly clientServiceConfig = ?;
 configurable TargetServerConfig targetServerConfig = ?;
 configurable ClientFhirServerConfig & readonly clientFhirServerConfig = ?;


### PR DESCRIPTION
## Purpose
> $Subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint introduced for retrieving specific PayerDataExchangeRequest records by request ID, featuring comprehensive error handling and user-friendly error messages for missing requests.

* **Chores**
  * Removed test server configuration entries to streamline system settings.
  * Integrated URL module dependency to enhance request handling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->