### PR TITLE
Revert "[bulkExportClient] Remove _since due to fhir repo not supporting"

### DIFF
--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -201,10 +201,7 @@ isolated service /pdex on bulkExportListener {
         log:printDebug("Extracted matched patient.", requestId = requestId, patientId = matchedPatient.id, systemId = matchedPatient.systemId ?: "");
 
         string? _outputFormat = ();
-        string? _since = ();
-        // string? _since = request.coverageStartDate;
-        // TODO: _since parameter is not supported for /Patient/ID/$export in fhir repository
-        // Issue: https://github.com/wso2-enterprise/open-healthcare/issues/2005
+        string? _since = request.coverageStartDate;
 
         // Defining types to export, maybe configurable or fixed for PDEX.
         string _type = "Patient,ExplanationOfBenefit,Coverage,AllergyIntolerance,Condition,Immunization,Procedure,Encounter,Observation";


### PR DESCRIPTION
Reverts wso2/reference-implementation-cms0057f#227 as Issue: https://github.com/wso2-enterprise/open-healthcare/issues/2005 is fixed and _since support for fhir repo is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk export filtering to properly apply the coverage start date parameter when exporting resources, ensuring accurate time-based constraints on exported data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->