### PR TITLE
Add API configurations for Condition, CarePlan, CareTeam, Medication,…

### DIFF
--- a/fhir-service/api_config.bal
+++ b/fhir-service/api_config.bal
@@ -3589,3 +3589,339 @@ final r4:ResourceAPIConfig conceptmapApiConfig = {
     serverConfig: (),
     authzConfig: ()
 };
+
+# ######################################################################################################################
+# Condition API Configs                                                                                                 #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig conditionApiConfig = {
+    resourceType: "Condition",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-problems-health-concerns",
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "Who has the condition?",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"
+            }
+        },
+        {
+            name: "category",
+            active: true,
+            information: {
+                description: "The category of the condition",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category"
+            }
+        },
+        {
+            name: "clinical-status",
+            active: true,
+            information: {
+                description: "The clinical status of the condition",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status"
+            }
+        },
+        {
+            name: "code",
+            active: true,
+            information: {
+                description: "Code for the condition",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code"
+            }
+        },
+        {
+            name: "encounter",
+            active: true,
+            information: {
+                description: "Encounter when condition first asserted",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-encounter"
+            }
+        },
+        {
+            name: "onset-date",
+            active: true,
+            information: {
+                description: "Date-related searches may have comparators",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date"
+            }
+        },
+        {
+            name: "abatement-date",
+            active: true,
+            information: {
+                description: "Date-related searches may have comparators",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-abatement-date"
+            }
+        },
+        {
+            name: "recorded-date",
+            active: true,
+            information: {
+                description: "Date record was first recorded",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-recorded-date"
+            }
+        },
+        {
+            name: "asserted-date",
+            active: true,
+            information: {
+                description: "Date the condition was first asserted (US Core extension)",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-asserted-date"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# CarePlan API Configs                                                                                                  #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig carePlanApiConfig = {
+    resourceType: "CarePlan",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "Who the care plan is for",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"
+            }
+        },
+        {
+            name: "category",
+            active: true,
+            information: {
+                description: "Type of plan",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"
+            }
+        },
+        {
+            name: "date",
+            active: true,
+            information: {
+                description: "Time period plan covers",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date"
+            }
+        },
+        {
+            name: "status",
+            active: true,
+            information: {
+                description: "draft | active | on-hold | revoked | completed | entered-in-error | unknown",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# CareTeam API Configs                                                                                                  #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig careTeamApiConfig = {
+    resourceType: "CareTeam",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "Who care team is for",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient"
+            }
+        },
+        {
+            name: "role",
+            active: true,
+            information: {
+                description: "Type of involvement",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role"
+            }
+        },
+        {
+            name: "status",
+            active: true,
+            information: {
+                description: "proposed | active | suspended | inactive | entered-in-error",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# Medication API Configs                                                                                                #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig medicationApiConfig = {
+    resourceType: "Medication",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+    ],
+    defaultProfile: (),
+    searchParameters: [],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# MedicationDispense API Configs                                                                                        #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig medicationDispenseApiConfig = {
+    resourceType: "MedicationDispense",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationdispense"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "The identity of a patient to list dispenses for",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationdispense-patient"
+            }
+        },
+        {
+            name: "status",
+            active: true,
+            information: {
+                description: "preparation | in-progress | cancelled | on-hold | completed | entered-in-error | stopped | declined | unknown",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationdispense-status"
+            }
+        },
+        {
+            name: "type",
+            active: true,
+            information: {
+                description: "Returns dispenses of a specific type",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationdispense-type"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# RelatedPerson API Configs                                                                                             #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig relatedPersonApiConfig = {
+    resourceType: "RelatedPerson",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-relatedperson"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+        {
+            name: "_id",
+            active: true,
+            information: {
+                description: "Logical id of this artifact",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-relatedperson-id"
+            }
+        },
+        {
+            name: "name",
+            active: true,
+            information: {
+                description: "A server defined search that may match any of the string fields in HumanName",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-relatedperson-name"
+            }
+        },
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "The patient this related person is related to",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-relatedperson-patient"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};
+
+# ######################################################################################################################
+# Specimen API Configs                                                                                                  #
+# ######################################################################################################################
+
+final r4:ResourceAPIConfig specimenApiConfig = {
+    resourceType: "Specimen",
+    profiles: [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-specimen"
+    ],
+    defaultProfile: (),
+    searchParameters: [
+        {
+            name: "_id",
+            active: true,
+            information: {
+                description: "Logical id of this artifact",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-specimen-id"
+            }
+        },
+        {
+            name: "patient",
+            active: true,
+            information: {
+                description: "The patient the specimen comes from",
+                builtin: false,
+                documentation: "http://hl7.org/fhir/us/core/SearchParameter/us-core-specimen-patient"
+            }
+        }
+    ],
+    operations: [],
+    serverConfig: (),
+    authzConfig: ()
+};

--- a/fhir-service/oas/OpenAPI.yaml
+++ b/fhir-service/oas/OpenAPI.yaml
@@ -9346,13 +9346,6 @@ paths:
       - GET
       - RelatedPerson
       parameters:
-      - name: _id
-        in: query
-        description: Logical id of this artifact
-        required: false
-        schema:
-          type: string
-        x-wso2-oh-fhirType: token
       - name: name
         in: query
         description: A server defined search that may match any of the string fields in the HumanName
@@ -9425,13 +9418,6 @@ paths:
       - GET
       - Specimen
       parameters:
-      - name: _id
-        in: query
-        description: Logical id of this artifact
-        required: false
-        schema:
-          type: string
-        x-wso2-oh-fhirType: token
       - name: patient
         in: query
         description: The patient the specimen comes from
@@ -11572,6 +11558,7 @@ components:
       explode: true
       schema:
         type: string
+      x-wso2-oh-fhirType: token
     _sourceParam:
       name: _source
       in: query

--- a/fhir-service/oas/OpenAPI.yaml
+++ b/fhir-service/oas/OpenAPI.yaml
@@ -8917,6 +8917,580 @@ paths:
       security:
       - default: []
       x-auth-type: Application & Application User
+  /Condition:
+    get:
+      tags:
+      - GET
+      - Condition
+      parameters:
+      - name: patient
+        in: query
+        description: Who has the condition?
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - name: category
+        in: query
+        description: The category of the condition
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: clinical-status
+        in: query
+        description: The clinical status of the condition
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: code
+        in: query
+        description: Code for the condition
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: encounter
+        in: query
+        description: Encounter created as part of
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - name: onset-date
+        in: query
+        description: Date related onsets (dateTime and Period)
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: date
+      - name: abatement-date
+        in: query
+        description: Date-related abatements (dateTime and period)
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: date
+      - name: recorded-date
+        in: query
+        description: Date record was first recorded
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: date
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search Condition operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new Condition
+      tags:
+      - POST
+      - Condition
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/Condition'
+      responses:
+        '201':
+          description: Successfully created Condition
+  /Condition/{id}:
+    get:
+      tags:
+      - GET
+      - Condition
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read Condition operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Condition'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /CarePlan:
+    get:
+      tags:
+      - GET
+      - CarePlan
+      parameters:
+      - name: patient
+        in: query
+        description: Who the care plan is for
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - name: category
+        in: query
+        description: Type of plan
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: date
+        in: query
+        description: Time period plan covers
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: date
+      - name: status
+        in: query
+        description: draft | active | on-hold | revoked | completed | entered-in-error | unknown
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search CarePlan operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new CarePlan
+      tags:
+      - POST
+      - CarePlan
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/CarePlan'
+      responses:
+        '201':
+          description: Successfully created CarePlan
+  /CarePlan/{id}:
+    get:
+      tags:
+      - GET
+      - CarePlan
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read CarePlan operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/CarePlan'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /CareTeam:
+    get:
+      tags:
+      - GET
+      - CareTeam
+      parameters:
+      - name: patient
+        in: query
+        description: Who care team is for
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - name: role
+        in: query
+        description: Type of involvement
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: status
+        in: query
+        description: proposed | active | suspended | inactive | entered-in-error
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search CareTeam operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new CareTeam
+      tags:
+      - POST
+      - CareTeam
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/CareTeam'
+      responses:
+        '201':
+          description: Successfully created CareTeam
+  /CareTeam/{id}:
+    get:
+      tags:
+      - GET
+      - CareTeam
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read CareTeam operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/CareTeam'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /Medication:
+    get:
+      tags:
+      - GET
+      - Medication
+      parameters:
+      - name: code
+        in: query
+        description: Returns medications for a specific code
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search Medication operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new Medication
+      tags:
+      - POST
+      - Medication
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/Medication'
+      responses:
+        '201':
+          description: Successfully created Medication
+  /Medication/{id}:
+    get:
+      tags:
+      - GET
+      - Medication
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read Medication operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Medication'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /MedicationDispense:
+    get:
+      tags:
+      - GET
+      - MedicationDispense
+      parameters:
+      - name: patient
+        in: query
+        description: The identity of a patient to list dispenses for
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - name: status
+        in: query
+        description: Returns dispenses with a specified dispense status
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: type
+        in: query
+        description: Returns dispenses of a specific type
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search MedicationDispense operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new MedicationDispense
+      tags:
+      - POST
+      - MedicationDispense
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/MedicationDispense'
+      responses:
+        '201':
+          description: Successfully created MedicationDispense
+  /MedicationDispense/{id}:
+    get:
+      tags:
+      - GET
+      - MedicationDispense
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read MedicationDispense operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/MedicationDispense'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /RelatedPerson:
+    get:
+      tags:
+      - GET
+      - RelatedPerson
+      parameters:
+      - name: _id
+        in: query
+        description: Logical id of this artifact
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: name
+        in: query
+        description: A server defined search that may match any of the string fields in the HumanName
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: string
+      - name: patient
+        in: query
+        description: The patient this related person is related to
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search RelatedPerson operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new RelatedPerson
+      tags:
+      - POST
+      - RelatedPerson
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/RelatedPerson'
+      responses:
+        '201':
+          description: Successfully created RelatedPerson
+  /RelatedPerson/{id}:
+    get:
+      tags:
+      - GET
+      - RelatedPerson
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read RelatedPerson operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/RelatedPerson'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+  /Specimen:
+    get:
+      tags:
+      - GET
+      - Specimen
+      parameters:
+      - name: _id
+        in: query
+        description: Logical id of this artifact
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: token
+      - name: patient
+        in: query
+        description: The patient the specimen comes from
+        required: false
+        schema:
+          type: string
+        x-wso2-oh-fhirType: reference
+      - $ref: '#/components/parameters/_lastUpdatedParam'
+      - $ref: '#/components/parameters/_securityParam'
+      - $ref: '#/components/parameters/_tagParam'
+      - $ref: '#/components/parameters/_idParam'
+      - $ref: '#/components/parameters/_sourceParam'
+      - $ref: '#/components/parameters/_profileParam'
+      responses:
+        '200':
+          description: search Specimen operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Bundle'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+    post:
+      summary: Create a new Specimen
+      tags:
+      - POST
+      - Specimen
+      requestBody:
+        required: true
+        content:
+          application/fhir+json:
+            schema:
+              $ref: '#/components/schemas/Specimen'
+      responses:
+        '201':
+          description: Successfully created Specimen
+  /Specimen/{id}:
+    get:
+      tags:
+      - GET
+      - Specimen
+      parameters:
+      - name: id
+        in: path
+        description: logical identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: read Specimen operation successful
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Specimen'
+      security:
+      - default: []
+      x-auth-type: Application & Application User
 components:
   schemas:
     Resource:
@@ -10772,6 +11346,16 @@ components:
           usedCode:
             $ref: '#/components/schemas/CodeableConcept'
     Medication:
+      allOf:
+      - $ref: '#/components/schemas/DomainResource'
+      - type: object
+        properties: {}
+    MedicationDispense:
+      allOf:
+      - $ref: '#/components/schemas/DomainResource'
+      - type: object
+        properties: {}
+    Specimen:
       allOf:
       - $ref: '#/components/schemas/DomainResource'
       - type: object

--- a/fhir-service/records.bal
+++ b/fhir-service/records.bal
@@ -280,6 +280,11 @@ public enum ResourceType {
     GROUP = "Group",
     SERVICE_REQUEST = "ServiceRequest",
     VALUE_SET = "ValueSet",
+    CARE_TEAM = "CareTeam",
+    MEDICATION = "Medication",
+    MEDICATION_DISPENSE = "MedicationDispense",
+    RELATED_PERSON = "RelatedPerson",
+    SPECIMEN = "Specimen",
     AUDIT_EVENT = "AuditEvent"
 }
 

--- a/fhir-service/service.bal
+++ b/fhir-service/service.bal
@@ -3222,3 +3222,325 @@ service /fhir/r4/ConceptMap on new fhirr4:Listener(config = conceptmapApiConfig)
         return invokeOperation(CONCEPT_MAP, "$translate", fhirClient:POST, id = id, queryParameters = queryParams);
     }
 }
+
+// ######################################################################################################################
+// # Condition API                                                                                                       #
+// ######################################################################################################################
+
+public type Condition uscore501:USCoreConditionProblemsHealthConcernsProfile|uscore501:USCoreConditionEncounterDiagnosisProfile;
+
+service /fhir/r4/Condition on new fhirr4:Listener(config = conditionApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, CONDITION, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, CONDITION, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, Condition condition) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, CONDITION, condition.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, Condition condition) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # CarePlan API                                                                                                        #
+// ######################################################################################################################
+
+public type CarePlan uscore501:USCoreCarePlanProfile;
+
+service /fhir/r4/CarePlan on new fhirr4:Listener(config = carePlanApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, CARE_PLAN, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, CARE_PLAN, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, CarePlan carePlan) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, CARE_PLAN, carePlan.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, CarePlan carePlan) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # CareTeam API                                                                                                        #
+// ######################################################################################################################
+
+public type CareTeam uscore501:USCoreCareTeam;
+
+service /fhir/r4/CareTeam on new fhirr4:Listener(config = careTeamApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, CARE_TEAM, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, CARE_TEAM, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, CareTeam careTeam) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, CARE_TEAM, careTeam.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, CareTeam careTeam) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # Medication API                                                                                                      #
+// ######################################################################################################################
+
+public type Medication uscore501:USCoreMedicationProfile;
+
+service /fhir/r4/Medication on new fhirr4:Listener(config = medicationApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, MEDICATION, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, MEDICATION, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, Medication medication) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, MEDICATION, medication.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, Medication medication) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # MedicationDispense API                                                                                              #
+// ######################################################################################################################
+
+public type MedicationDispense international401:MedicationDispense;
+
+service /fhir/r4/MedicationDispense on new fhirr4:Listener(config = medicationDispenseApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, MEDICATION_DISPENSE, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, MEDICATION_DISPENSE, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, MedicationDispense medicationDispense) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, MEDICATION_DISPENSE, medicationDispense.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, MedicationDispense medicationDispense) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # RelatedPerson API                                                                                                   #
+// ######################################################################################################################
+
+public type RelatedPerson uscore501:USCoreRelatedPersonProfile;
+
+service /fhir/r4/RelatedPerson on new fhirr4:Listener(config = relatedPersonApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, RELATED_PERSON, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, RELATED_PERSON, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, RelatedPerson relatedPerson) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, RELATED_PERSON, relatedPerson.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, RelatedPerson relatedPerson) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}
+
+// ######################################################################################################################
+// # Specimen API                                                                                                        #
+// ######################################################################################################################
+
+public type Specimen international401:Specimen;
+
+service /fhir/r4/Specimen on new fhirr4:Listener(config = specimenApiConfig) {
+
+    isolated resource function get [string id](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return getById(fhirConnector, SPECIMEN, id);
+    }
+
+    isolated resource function get [string id]/_history/[string vid](r4:FHIRContext fhirContext) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get .(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        map<string[]> queryParamsMap = getQueryParamsMap(fhirContext.getRequestSearchParameters());
+        return search(fhirConnector, SPECIMEN, queryParamsMap, fhirContext);
+    }
+
+    isolated resource function post .(r4:FHIRContext fhirContext, Specimen specimen) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return create(fhirConnector, SPECIMEN, specimen.toJson(), fhirContext);
+    }
+
+    isolated resource function put [string id](r4:FHIRContext fhirContext, Specimen specimen) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function patch [string id](r4:FHIRContext fhirContext, json patch) returns r4:DomainResource|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function delete [string id](r4:FHIRContext fhirContext) returns r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get [string id]/_history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+
+    isolated resource function get _history(r4:FHIRContext fhirContext) returns r4:Bundle|r4:OperationOutcome|r4:FHIRError {
+        return r4:createFHIRError("Not implemented", r4:ERROR, r4:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+    }
+}

--- a/fhir-service/service.bal
+++ b/fhir-service/service.bal
@@ -49,9 +49,9 @@ configurable string bulkMemberMatchMode = "respond-async";
 configurable string[] & readonly allowedExportResourceTypes = [
     "AllergyIntolerance", "CarePlan", "CareTeam", "Condition", "Consent",
     "Coverage", "Device", "DiagnosticReport", "DocumentReference", "Encounter",
-    "ExplanationOfBenefit", "Goal", "Immunization", "MedicationDispense",
+    "ExplanationOfBenefit", "Goal", "Immunization", "Medication", "MedicationDispense",
     "MedicationRequest", "Observation", "Patient", "Practitioner", "PractitionerRole",
-    "Procedure", "Provenance", "RelatedPerson", "ServiceRequest"
+    "Procedure", "Provenance", "RelatedPerson", "ServiceRequest", "Specimen"
 ];
 
 // This is used to connect to file service


### PR DESCRIPTION
## Purpose
Add missing FHIR resource endpoints and OpenAPI specification entries for Condition, CarePlan, CareTeam, Medication, MedicationDispense, RelatedPerson, and Specimen resources to support PDex bulk data exchange workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for seven new FHIR R4 resources: Condition, CarePlan, CareTeam, Medication, MedicationDispense, RelatedPerson, and Specimen
  * Each resource exposes search, create (POST), and read (GET by id) REST endpoints with standard FHIR query parameters and Bundle/resource responses
  * Medication and Specimen are now allowed for export and included in API schemas and type mappings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->