### PR TITLE
Added new workflow `pdex/trigger-bulk-data-exchange` to bulk-export-client 

### DIFF
--- a/bulk-export-client/Ballerina.toml
+++ b/bulk-export-client/Ballerina.toml
@@ -7,3 +7,13 @@ distribution = "2201.12.10"
 [build-options]
 observabilityIncluded = true
 
+[[dependency]]
+org = "ballerinax"
+name = "health.fhir.r4.davincipdex220"
+version = "1.0.1"
+
+[[dependency]]
+org = "ballerinax"
+name = "health.fhir.r4.davincihrex100"
+version = "3.0.0"
+

--- a/bulk-export-client/Dependencies.toml
+++ b/bulk-export-client/Dependencies.toml
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/bulk-export-client/bulk_match_polling.bal
+++ b/bulk-export-client/bulk_match_polling.bal
@@ -116,7 +116,7 @@ public class BulkMatchPollingTask {
                 jobId = self.jobId, payload = payload.toJsonString());
             BulkMatchResponseResult result = check extractBulkMatchResult(
                 payload, self.memberIdToRequestIdMap);
-            log:printInfo("Bulk match result extracted.",
+            log:printDebug("Bulk match result extracted.",
                 jobId = self.jobId,
                 matchedGroupId = result.matchedGroupId,
                 matchedCount = result.matchedRequestIds.length(),

--- a/bulk-export-client/bulk_match_polling.bal
+++ b/bulk-export-client/bulk_match_polling.bal
@@ -1,0 +1,388 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/task;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+isolated function updateJobStatus(string jobId, string status) {
+    string|error res = updateBulkExportJobStatus(jobId, status);
+    if res is error {
+        log:printError("Failed to update bulk export job status.", res, jobId = jobId, status = status);
+    }
+}
+
+isolated function markAllFailed(string[] requestIds, string label) {
+    foreach string reqId in requestIds {
+        string|error res = updatePayerDataExchangeRequestStatus(reqId, "FAILED");
+        if res is error {
+            log:printError("Failed to mark request FAILED (" + label + ").", res, requestId = reqId);
+        }
+    }
+}
+
+isolated function safeUnschedule(task:JobId scheduledId, string label) {
+    error? res = unscheduleJob(scheduledId);
+    if res is error {
+        log:printError("Error unscheduling job (" + label + ").", res);
+    }
+}
+
+// ─── Stage 1: poll $bulk-member-match ───────────────────────────────────────
+
+const int BULK_MATCH_MAX_POLLS = 60;
+
+public class BulkMatchPollingTask {
+    *task:Job;
+
+    string jobId;
+    string pollingUrl;
+    BulkExportServerConfig serverConfig;
+    map<string> memberIdToRequestIdMap;
+    string[] requestIds;
+    string payerId;
+    string oldPayerName;
+    task:JobId scheduledJobId = {id: 0};
+    int pollCount = 0;
+
+    public isolated function init(
+        string jobId,
+        string pollingUrl,
+        BulkExportServerConfig serverConfig,
+        map<string> memberIdToRequestIdMap,
+        string[] requestIds,
+        string payerId,
+        string oldPayerName
+    ) {
+        self.jobId = jobId;
+        self.pollingUrl = pollingUrl;
+        self.serverConfig = serverConfig;
+        self.memberIdToRequestIdMap = memberIdToRequestIdMap;
+        self.requestIds = requestIds;
+        self.payerId = payerId;
+        self.oldPayerName = oldPayerName;
+    }
+
+    public function execute() {
+        do {
+            self.pollCount += 1;
+            log:printDebug("BulkMatchPollingTask poll attempt.",
+                jobId = self.jobId,
+                pollCount = self.pollCount,
+                maxPolls = BULK_MATCH_MAX_POLLS,
+                pollingUrl = self.pollingUrl);
+
+            if self.pollCount > BULK_MATCH_MAX_POLLS {
+                log:printError("BulkMatchPollingTask timed out — max polls exceeded.",
+                    jobId = self.jobId, polls = self.pollCount);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(self.requestIds, "polling-timeout");
+                safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask-timeout");
+                return;
+            }
+
+            BulkExportServerConfig pollingConfig = check self.serverConfig.cloneWithType();
+            pollingConfig.baseUrl = self.pollingUrl;
+            http:Client pollingClient = check createHttpClient(pollingConfig);
+            http:Response resp = check pollingClient->/;
+
+            int statusCode = resp.statusCode;
+            log:printDebug("BulkMatchPollingTask poll response.",
+                jobId = self.jobId,
+                pollCount = self.pollCount,
+                statusCode = statusCode);
+
+            if statusCode == 202 {
+                log:printDebug("Bulk match still processing.", jobId = self.jobId);
+                return;
+            }
+
+            // Unschedule Stage 1 — terminal response (200 or error)
+            safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask");
+
+            if statusCode != 200 {
+                log:printError("Bulk match polling unexpected status.",
+                    statusCode = statusCode, jobId = self.jobId);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(self.requestIds, "unexpected-status");
+                return;
+            }
+
+            // 200 — parse result
+            json payload = check resp.getJsonPayload();
+            log:printDebug("Bulk match 200 response payload.",
+                jobId = self.jobId, payload = payload.toJsonString());
+            BulkMatchResponseResult result = check extractBulkMatchResult(
+                payload, self.memberIdToRequestIdMap);
+            log:printInfo("Bulk match result extracted.",
+                jobId = self.jobId,
+                matchedGroupId = result.matchedGroupId,
+                matchedCount = result.matchedRequestIds.length(),
+                nonMatchedCount = result.nonMatchedRequestIds.length(),
+                consentConstrainedCount = result.consentConstrainedRequestIds.length(),
+                matchedRequestIds = result.matchedRequestIds.toString(),
+                nonMatchedRequestIds = result.nonMatchedRequestIds.toString(),
+                consentConstrainedRequestIds = result.consentConstrainedRequestIds.toString());
+
+            // Update job status
+            updateJobStatus(self.jobId, "BULK_MATCH_COMPLETED");
+
+            // Set granular statuses for non-matched / consent-constrained
+            foreach string reqId in result.nonMatchedRequestIds {
+                string|error res = updatePayerDataExchangeRequestStatus(reqId, "NOT_MATCHED");
+                if res is error {
+                    log:printError("Failed to mark request NOT_MATCHED.", res, requestId = reqId);
+                }
+            }
+            foreach string reqId in result.consentConstrainedRequestIds {
+                string|error res = updatePayerDataExchangeRequestStatus(reqId, "CONSENT_CONSTRAINED");
+                if res is error {
+                    log:printError("Failed to mark request CONSENT_CONSTRAINED.", res, requestId = reqId);
+                }
+            }
+
+            // Detect requests absent from all categories — correlation failure or omitted by old payer.
+            // These are process errors, not genuine non-matches, so mark them FAILED.
+            string[] coveredIds = [];
+            foreach string id in result.matchedRequestIds { coveredIds.push(id); }
+            foreach string id in result.nonMatchedRequestIds { coveredIds.push(id); }
+            foreach string id in result.consentConstrainedRequestIds { coveredIds.push(id); }
+
+            boolean hadUnaccountedRequests = false;
+            foreach string reqId in self.requestIds {
+                if coveredIds.indexOf(reqId) == () {
+                    hadUnaccountedRequests = true;
+                    log:printError("Request not accounted for in bulk match response — marking FAILED.",
+                        requestId = reqId, jobId = self.jobId);
+                    string|error res = updatePayerDataExchangeRequestStatus(reqId, "FAILED");
+                    if res is error {
+                        log:printError("Failed to mark unaccounted request FAILED.", res, requestId = reqId);
+                    }
+                }
+            }
+
+            if result.matchedRequestIds.length() == 0 {
+                string finalJobStatus = hadUnaccountedRequests ? "FAILED" : "COMPLETED";
+                log:printInfo("No matched members — closing job.",
+                    jobId = self.jobId, status = finalJobStatus);
+                updateJobStatus(self.jobId, finalJobStatus);
+                return;
+            }
+
+            // Mark matched requests as EXPORT_IN_PROGRESS
+            foreach string reqId in result.matchedRequestIds {
+                string|error res = updatePayerDataExchangeRequestStatus(reqId, "EXPORT_IN_PROGRESS");
+                if res is error {
+                    log:printError("Failed to mark request EXPORT_IN_PROGRESS.", res, requestId = reqId);
+                }
+            }
+
+            // Kick off $davinci-data-export
+            http:Client exportClient = check createHttpClient(self.serverConfig);
+            http:Response|http:ClientError exportResp = exportClient->post(
+                "/Group/" + result.matchedGroupId + "/$davinci-data-export",
+                (),
+                headers = {"Prefer": "respond-async"},
+                mediaType = "application/fhir+json"
+            );
+
+            if exportResp is http:ClientError {
+                log:printError("$davinci-data-export call failed.", exportResp, jobId = self.jobId);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(result.matchedRequestIds, "export-client-error");
+                return;
+            }
+
+            if exportResp.statusCode != 202 {
+                string|error errBody = exportResp.getTextPayload();
+                log:printError("$davinci-data-export unexpected status.",
+                    statusCode = exportResp.statusCode, jobId = self.jobId,
+                    body = errBody is string ? errBody : "(no body)");
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(result.matchedRequestIds, "export-status-error");
+                return;
+            }
+
+            string exportPollingUrl = check exportResp.getHeader("content-location");
+            log:printInfo("$davinci-data-export accepted.",
+                jobId = self.jobId, pollingUrl = exportPollingUrl);
+
+            // Advance job to EXPORT_POLLING stage
+            updateJobStatus(self.jobId, "EXPORT_POLLING");
+
+            error? schedErr = scheduleDaVinciExportJob(
+                new DaVinciExportPollingTask(
+                    self.jobId, exportPollingUrl, self.serverConfig,
+                    result.matchedRequestIds, self.payerId, self.oldPayerName
+                ),
+                clientServiceConfig.defaultIntervalInSec
+            );
+            if schedErr is error {
+                log:printError("Failed to schedule DaVinci export polling.", schedErr, jobId = self.jobId);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(result.matchedRequestIds, "schedule-error");
+            }
+
+        } on fail var e {
+            log:printError("BulkMatchPollingTask error. Marking all FAILED.", e, jobId = self.jobId);
+            updateJobStatus(self.jobId, "FAILED");
+            markAllFailed(self.requestIds, "task-on-fail");
+            safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask-on-fail");
+        }
+    }
+
+    public isolated function setId(task:JobId scheduledId) {
+        lock {
+            self.scheduledJobId = scheduledId;
+        }
+    }
+}
+
+// ─── Stage 2: poll $davinci-data-export ─────────────────────────────────────
+
+const int DAVINCI_EXPORT_MAX_POLLS = 60;
+
+public class DaVinciExportPollingTask {
+    *task:Job;
+
+    string jobId;
+    string pollingUrl;
+    BulkExportServerConfig serverConfig;
+    string[] matchedRequestIds;
+    string payerId;
+    string oldPayerName;
+    task:JobId scheduledJobId = {id: 0};
+    int pollCount = 0;
+
+    public isolated function init(
+        string jobId,
+        string pollingUrl,
+        BulkExportServerConfig serverConfig,
+        string[] matchedRequestIds,
+        string payerId,
+        string oldPayerName
+    ) {
+        self.jobId = jobId;
+        self.pollingUrl = pollingUrl;
+        self.serverConfig = serverConfig;
+        self.matchedRequestIds = matchedRequestIds;
+        self.payerId = payerId;
+        self.oldPayerName = oldPayerName;
+    }
+
+    public function execute() {
+        do {
+            self.pollCount += 1;
+            log:printDebug("DaVinciExportPollingTask poll attempt.",
+                jobId = self.jobId,
+                pollCount = self.pollCount,
+                maxPolls = DAVINCI_EXPORT_MAX_POLLS,
+                pollingUrl = self.pollingUrl);
+
+            if self.pollCount > DAVINCI_EXPORT_MAX_POLLS {
+                log:printError("DaVinciExportPollingTask timed out — max polls exceeded.",
+                    jobId = self.jobId, polls = self.pollCount);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(self.matchedRequestIds, "davinci-polling-timeout");
+                safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask-timeout");
+                return;
+            }
+
+            BulkExportServerConfig pollingConfig = check self.serverConfig.cloneWithType();
+            pollingConfig.baseUrl = self.pollingUrl;
+            http:Client pollingClient = check createHttpClient(pollingConfig);
+            http:Response resp = check pollingClient->/;
+
+            int statusCode = resp.statusCode;
+            log:printDebug("DaVinciExportPollingTask poll response.",
+                jobId = self.jobId,
+                pollCount = self.pollCount,
+                statusCode = statusCode);
+
+            if statusCode == 202 {
+                log:printDebug("DaVinci export still processing.", jobId = self.jobId);
+                return;
+            }
+
+            // Unschedule Stage 2 — terminal response
+            safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask");
+
+            if statusCode != 200 {
+                log:printError("DaVinci export polling unexpected status.",
+                    statusCode = statusCode, jobId = self.jobId);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(self.matchedRequestIds, "davinci-unexpected-status");
+                return;
+            }
+
+            // 200 — advance to SYNCING and sync data
+            updateJobStatus(self.jobId, "SYNCING");
+            foreach string reqId in self.matchedRequestIds {
+                string|error res = updatePayerDataExchangeRequestStatus(reqId, "SYNCING");
+                if res is error {
+                    log:printError("Failed to mark request SYNCING.", res, requestId = reqId);
+                }
+            }
+
+            json payload = check resp.getJsonPayload();
+            log:printDebug("DaVinci export manifest received.",
+                jobId = self.jobId, manifest = payload.toJsonString());
+            map<string> context = {
+                "jobId": self.jobId,
+                "payerId": self.payerId,
+                "oldPayerName": self.oldPayerName
+            };
+
+            error? syncErr = syncDataToFhirServer(self.jobId, payload, self.serverConfig, context);
+            if syncErr is error {
+                log:printError("Sync failed.", syncErr, jobId = self.jobId);
+                updateJobStatus(self.jobId, "FAILED");
+                markAllFailed(self.matchedRequestIds, "sync-error");
+                return;
+            }
+
+            // Sync succeeded — mark COMPLETED
+            updateJobStatus(self.jobId, "COMPLETED");
+            foreach string reqId in self.matchedRequestIds {
+                string|error res = updatePayerDataExchangeRequestStatus(reqId, "COMPLETED");
+                if res is error {
+                    log:printError("Failed to mark request COMPLETED.", res, requestId = reqId);
+                } else {
+                    log:printInfo("Request marked COMPLETED.", requestId = reqId, jobId = self.jobId);
+                }
+            }
+
+        } on fail var e {
+            log:printError("DaVinciExportPollingTask error. Marking matched FAILED.", e, jobId = self.jobId);
+            updateJobStatus(self.jobId, "FAILED");
+            markAllFailed(self.matchedRequestIds, "davinci-task-on-fail");
+            safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask-on-fail");
+        }
+    }
+
+    public isolated function setId(task:JobId scheduledId) {
+        lock {
+            self.scheduledJobId = scheduledId;
+        }
+    }
+}
+
+// ─── Schedulers ─────────────────────────────────────────────────────────────
+
+public isolated function scheduleBulkMatchJob(
+    BulkMatchPollingTask job,
+    decimal interval
+) returns error? {
+    task:JobId id = check task:scheduleJobRecurByFrequency(job, interval);
+    job.setId(id);
+}
+
+public isolated function scheduleDaVinciExportJob(
+    DaVinciExportPollingTask job,
+    decimal interval
+) returns error? {
+    task:JobId id = check task:scheduleJobRecurByFrequency(job, interval);
+    job.setId(id);
+}

--- a/bulk-export-client/bulk_match_polling.bal
+++ b/bulk-export-client/bulk_match_polling.bal
@@ -79,7 +79,7 @@ public class BulkMatchPollingTask {
                     jobId = self.jobId, polls = self.pollCount);
                 updateJobStatus(self.jobId, "FAILED");
                 markAllFailed(self.requestIds, "polling-timeout");
-                safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask-timeout");
+                safeUnschedule(self.getScheduledJobId(), "BulkMatchPollingTask-timeout");
                 return;
             }
 
@@ -100,7 +100,7 @@ public class BulkMatchPollingTask {
             }
 
             // Unschedule Stage 1 — terminal response (200 or error)
-            safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask");
+            safeUnschedule(self.getScheduledJobId(), "BulkMatchPollingTask");
 
             if statusCode != 200 {
                 log:printError("Bulk match polling unexpected status.",
@@ -229,13 +229,19 @@ public class BulkMatchPollingTask {
             log:printError("BulkMatchPollingTask error. Marking all FAILED.", e, jobId = self.jobId);
             updateJobStatus(self.jobId, "FAILED");
             markAllFailed(self.requestIds, "task-on-fail");
-            safeUnschedule(self.scheduledJobId, "BulkMatchPollingTask-on-fail");
+            safeUnschedule(self.getScheduledJobId(), "BulkMatchPollingTask-on-fail");
         }
     }
 
     public isolated function setId(task:JobId scheduledId) {
         lock {
             self.scheduledJobId = scheduledId;
+        }
+    }
+
+    public isolated function getScheduledJobId() returns task:JobId {
+        lock {
+            return self.scheduledJobId;
         }
     }
 }
@@ -286,7 +292,7 @@ public class DaVinciExportPollingTask {
                     jobId = self.jobId, polls = self.pollCount);
                 updateJobStatus(self.jobId, "FAILED");
                 markAllFailed(self.matchedRequestIds, "davinci-polling-timeout");
-                safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask-timeout");
+                safeUnschedule(self.getScheduledJobId(), "DaVinciExportPollingTask-timeout");
                 return;
             }
 
@@ -307,7 +313,7 @@ public class DaVinciExportPollingTask {
             }
 
             // Unschedule Stage 2 — terminal response
-            safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask");
+            safeUnschedule(self.getScheduledJobId(), "DaVinciExportPollingTask");
 
             if statusCode != 200 {
                 log:printError("DaVinci export polling unexpected status.",
@@ -358,13 +364,19 @@ public class DaVinciExportPollingTask {
             log:printError("DaVinciExportPollingTask error. Marking matched FAILED.", e, jobId = self.jobId);
             updateJobStatus(self.jobId, "FAILED");
             markAllFailed(self.matchedRequestIds, "davinci-task-on-fail");
-            safeUnschedule(self.scheduledJobId, "DaVinciExportPollingTask-on-fail");
+            safeUnschedule(self.getScheduledJobId(), "DaVinciExportPollingTask-on-fail");
         }
     }
 
     public isolated function setId(task:JobId scheduledId) {
         lock {
             self.scheduledJobId = scheduledId;
+        }
+    }
+
+    public isolated function getScheduledJobId() returns task:JobId {
+        lock {
+            return self.scheduledJobId;
         }
     }
 }

--- a/bulk-export-client/bulk_match_polling.bal
+++ b/bulk-export-client/bulk_match_polling.bal
@@ -1,5 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 import ballerina/http;
 import ballerina/log;

--- a/bulk-export-client/bulk_match_polling.bal
+++ b/bulk-export-client/bulk_match_polling.bal
@@ -74,6 +74,15 @@ public class BulkMatchPollingTask {
                 maxPolls = BULK_MATCH_MAX_POLLS,
                 pollingUrl = self.pollingUrl);
 
+            // Short-circuit if the job was externally cancelled (e.g., by the reset endpoint)
+            BulkExportJob|error currentJob = getBulkExportJob(self.jobId);
+            if currentJob is BulkExportJob && currentJob.status == "FAILED" {
+                log:printInfo("BulkMatchPollingTask: job cancelled externally; unscheduling.",
+                    jobId = self.jobId);
+                safeUnschedule(self.getScheduledJobId(), "BulkMatchPollingTask-cancelled");
+                return;
+            }
+
             if self.pollCount > BULK_MATCH_MAX_POLLS {
                 log:printError("BulkMatchPollingTask timed out — max polls exceeded.",
                     jobId = self.jobId, polls = self.pollCount);
@@ -85,8 +94,18 @@ public class BulkMatchPollingTask {
 
             BulkExportServerConfig pollingConfig = check self.serverConfig.cloneWithType();
             pollingConfig.baseUrl = self.pollingUrl;
-            http:Client pollingClient = check createHttpClient(pollingConfig);
-            http:Response resp = check pollingClient->/;
+            http:Client|error pollingClientResult = createHttpClient(pollingConfig);
+            if pollingClientResult is error {
+                log:printWarn("BulkMatchPollingTask: transient error creating HTTP client; will retry.",
+                    pollingClientResult, jobId = self.jobId, pollCount = self.pollCount);
+                return;
+            }
+            http:Response|http:ClientError resp = pollingClientResult->/;
+            if resp is http:ClientError {
+                log:printWarn("BulkMatchPollingTask: transient HTTP error during poll; will retry.",
+                    resp, jobId = self.jobId, pollCount = self.pollCount);
+                return;
+            }
 
             int statusCode = resp.statusCode;
             log:printDebug("BulkMatchPollingTask poll response.",
@@ -287,6 +306,15 @@ public class DaVinciExportPollingTask {
                 maxPolls = DAVINCI_EXPORT_MAX_POLLS,
                 pollingUrl = self.pollingUrl);
 
+            // Short-circuit if the job was externally cancelled (e.g., by the reset endpoint)
+            BulkExportJob|error currentDavinciJob = getBulkExportJob(self.jobId);
+            if currentDavinciJob is BulkExportJob && currentDavinciJob.status == "FAILED" {
+                log:printInfo("DaVinciExportPollingTask: job cancelled externally; unscheduling.",
+                    jobId = self.jobId);
+                safeUnschedule(self.getScheduledJobId(), "DaVinciExportPollingTask-cancelled");
+                return;
+            }
+
             if self.pollCount > DAVINCI_EXPORT_MAX_POLLS {
                 log:printError("DaVinciExportPollingTask timed out — max polls exceeded.",
                     jobId = self.jobId, polls = self.pollCount);
@@ -298,8 +326,18 @@ public class DaVinciExportPollingTask {
 
             BulkExportServerConfig pollingConfig = check self.serverConfig.cloneWithType();
             pollingConfig.baseUrl = self.pollingUrl;
-            http:Client pollingClient = check createHttpClient(pollingConfig);
-            http:Response resp = check pollingClient->/;
+            http:Client|error pollingClientResult = createHttpClient(pollingConfig);
+            if pollingClientResult is error {
+                log:printWarn("DaVinciExportPollingTask: transient error creating HTTP client; will retry.",
+                    pollingClientResult, jobId = self.jobId, pollCount = self.pollCount);
+                return;
+            }
+            http:Response|http:ClientError resp = pollingClientResult->/;
+            if resp is http:ClientError {
+                log:printWarn("DaVinciExportPollingTask: transient HTTP error during poll; will retry.",
+                    resp, jobId = self.jobId, pollCount = self.pollCount);
+                return;
+            }
 
             int statusCode = resp.statusCode;
             log:printDebug("DaVinciExportPollingTask poll response.",

--- a/bulk-export-client/bulk_match_records.bal
+++ b/bulk-export-client/bulk_match_records.bal
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Request payload for POST /pdex/trigger-bulk-data-exchange.
+public type TriggerBulkDataExchangeRequest record {|
+    string[] requestIds;
+|};
+
+# Result of buildBulkMemberMatchParams — the Parameters JSON ready to POST
+# to $bulk-member-match, plus a map to correlate response members back to requestIds.
+#
+# + params                 - Parameters JSON with MemberBundle[] for $bulk-member-match
+# + memberIdToRequestIdMap - memberId -> requestId (used for response correlation)
+public type BulkMatchParamsResult record {|
+    json params;
+    map<string> memberIdToRequestIdMap;
+|};
+
+# Parsed result of the $bulk-member-match 200 response.
+#
+# + matchedGroupId                  - id of the MatchedMembers Group persisted in fhir-service
+# + matchedRequestIds               - requestIds successfully matched (stay IN_PROGRESS)
+# + nonMatchedRequestIds            - requestIds with no demographic match (-> FAILED)
+# + consentConstrainedRequestIds    - requestIds matched but consent failed (-> FAILED)
+public type BulkMatchResponseResult record {|
+    string matchedGroupId;
+    string[] matchedRequestIds;
+    string[] nonMatchedRequestIds;
+    string[] consentConstrainedRequestIds;
+|};
+
+# Record to represent a bulk export job in the database.
+#
+# + jobId - Unique job identifier (UUID)
+# + payerId - Payer this job targets
+# + status - Overall job status (INITIATED, BULK_MATCH_POLLING, BULK_MATCH_COMPLETED,
+#            EXPORT_POLLING, SYNCING, COMPLETED, FAILED)
+# + createdAt - Job creation timestamp
+# + completedAt - Job completion timestamp (set when COMPLETED or FAILED)
+public type BulkExportJob record {|
+    string jobId;
+    string payerId;
+    string status;
+    string? createdAt = ();
+    string? completedAt = ();
+|};
+
+# Response for GET /pdex/bulk-export-jobs/{jobId}.
+# The job is the single polling entry point. Individual request statuses
+# provide the full breakdown of matched/not-matched/consent-constrained.
+#
+# + job - The bulk export job details
+# + requests - Individual request statuses linked to this job
+public type BulkExportJobStatusResponse record {|
+    BulkExportJob job;
+    PayerDataExchangeRequest[] requests;
+|};

--- a/bulk-export-client/bulk_match_records.bal
+++ b/bulk-export-client/bulk_match_records.bal
@@ -12,6 +12,7 @@
 // under the License.
 
 # Request payload for POST /pdex/trigger-bulk-data-exchange.
+# + requestIds - Array of requestIds to trigger bulk data exchange for. These should correspond to existing PayerDataExchangeRequest records in the database.
 public type TriggerBulkDataExchangeRequest record {|
     string[] requestIds;
 |};

--- a/bulk-export-client/bulk_match_utils.bal
+++ b/bulk-export-client/bulk_match_utils.bal
@@ -1,0 +1,297 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+import ballerina/http;
+import ballerina/log;
+
+# Build Parameters JSON for POST /Group/$bulk-member-match.
+# Fetches each member's Patient from the local FHIR server and wraps it in a MemberBundle.
+#
+# + requests   - List of PDex exchange requests to include in the batch
+# + fhirClient - HTTP client pointed at the LOCAL FHIR server (to fetch Patient resources)
+# + return     - BulkMatchParamsResult or error
+public isolated function buildBulkMemberMatchParams(
+    PayerDataExchangeRequest[] requests,
+    http:Client fhirClient
+) returns BulkMatchParamsResult|error {
+
+    json[] memberBundles = [];
+    map<string> memberIdToRequestIdMap = {};
+
+    foreach PayerDataExchangeRequest request in requests {
+        string memberId = request.memberId;
+        string requestId = request.requestId ?: "";
+
+        // 1. Fetch Patient from local FHIR server
+        json|error patientResult = fhirClient->get("/Patient/" + memberId);
+        if patientResult is error {
+            log:printError("Failed to fetch patient for bulk match", patientResult, memberId = memberId);
+            return error("Failed to fetch patient details for member: " + memberId);
+        }
+        map<json> patientMap = check patientResult.ensureType();
+
+        // 2. Build MemberPatient JSON — keep only required demographic fields
+        map<json> memberPatient = {
+            "resourceType": "Patient",
+            "id": memberId
+        };
+        foreach string 'field in ["identifier", "name", "address", "telecom", "gender", "birthDate"] {
+            if patientMap.hasKey('field) {
+                memberPatient['field] = patientMap.get('field);
+            }
+        }
+
+        // 3. Build part[] array for the MemberBundle
+        json[] parts = [
+            {"name": "MemberPatient", "resource": memberPatient}
+        ];
+
+        // 4. CoverageToMatch (only if oldCoverageId is provided)
+        if request.oldCoverageId != () {
+            json coverageToMatch = {
+                "resourceType": "Coverage",
+                "id": request.oldCoverageId ?: "",
+                "status": "active",
+                "subscriberId": memberId,
+                "beneficiary": {"reference": "Patient/" + memberId},
+                "payor": [{"display": request.oldPayerName}]
+            };
+            parts.push({"name": "CoverageToMatch", "resource": coverageToMatch});
+        }
+
+        // 5. CoverageToLink (always present — links to new payer)
+        json coverageToLink = {
+            "resourceType": "Coverage",
+            "status": "active",
+            "subscriberId": memberId,
+            "beneficiary": {"reference": "Patient/" + memberId},
+            "payor": [{"display": clientServiceConfig.newPayerName}]
+        };
+        parts.push({"name": "CoverageToLink", "resource": coverageToLink});
+
+        // 6. Consent (if consent field is set on the request)
+        if request.consent != () {
+            json consent = {
+                "resourceType": "Consent",
+                "status": "active",
+                "scope": {
+                    "coding": [{"system": "http://terminology.hl7.org/CodeSystem/consentscope", "code": "patient-privacy"}]
+                },
+                "category": [
+                    {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "IDSCL"}]}
+                ],
+                "patient": {"reference": "Patient/" + memberId},
+                "performer": [{"reference": "Patient/" + memberId}],
+                "sourceReference": {"reference": "http://example.org/DocumentReference/someconsent"},
+                "policy": [{"uri": "http://hl7.org/fhir/us/davinci-hrex/StructureDefinition-hrex-consent.html#regular"}],
+                "provision": {
+                    "type": "permit",
+                    "period": {
+                        "start": request.coverageStartDate,
+                        "end": request.coverageEndDate
+                    },
+                    "actor": [
+                        {
+                            "role": {
+                                "coding": [{"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type", "code": "performer"}]
+                            },
+                            "reference": {
+                                "identifier": {"system": "http://hl7.org/fhir/sid/us-npi", "value": request.payerId},
+                                "display": request.oldPayerName
+                            }
+                        },
+                        {
+                            "role": {
+                                "coding": [{"system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType", "code": "IRCP"}]
+                            },
+                            "reference": {
+                                "identifier": {"system": "http://hl7.org/fhir/sid/us-npi", "value": clientServiceConfig.newPayerNpi},
+                                "display": clientServiceConfig.newPayerName
+                            }
+                        }
+                    ],
+                    "action": [
+                        {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/consentaction", "code": "disclose"}]}
+                    ]
+                }
+            };
+            parts.push({"name": "Consent", "resource": consent});
+        }
+
+        // 7. Wrap in MemberBundle
+        memberBundles.push({"name": "MemberBundle", "part": parts});
+
+        // 8. Track correlation — index by memberId AND by every patient identifier value.
+        //    The old payer echoes back our submitted identifier values on the contained patients
+        //    in the response Group, so we need those values as lookup keys too.
+        memberIdToRequestIdMap[memberId] = requestId;
+        json patientIdentifiers = patientMap["identifier"];
+        if patientIdentifiers is json[] {
+            foreach json idEntry in patientIdentifiers {
+                if idEntry is map<json> {
+                    json idValue = idEntry["value"];
+                    if idValue is string && idValue != "" {
+                        memberIdToRequestIdMap[idValue] = requestId;
+                    }
+                }
+            }
+        }
+    }
+
+    json params = {
+        "resourceType": "Parameters",
+        "parameter": memberBundles
+    };
+
+    return {params, memberIdToRequestIdMap};
+}
+
+# Parse the 200 response from $bulk-member-match polling.
+# Extracts the MatchedMembers Group ID and correlates members back to requestIds.
+#
+# + responsePayload        - JSON body of the 200 polling response
+# + memberIdToRequestIdMap - memberId -> requestId built during param construction
+# + return                 - BulkMatchResponseResult or error
+public isolated function extractBulkMatchResult(
+    json responsePayload,
+    map<string> memberIdToRequestIdMap
+) returns BulkMatchResponseResult|error {
+
+    map<json> payloadMap = check responsePayload.ensureType();
+    json resourceTypeVal = payloadMap["resourceType"];
+    if resourceTypeVal !is string || resourceTypeVal != "Parameters" {
+        return error("Expected Parameters resource in bulk match response");
+    }
+
+    json parameterVal = payloadMap["parameter"];
+    if parameterVal !is json[] {
+        return error("Expected parameter array in bulk match response");
+    }
+
+    string matchedGroupId = "";
+    string[] matchedRequestIds = [];
+    string[] nonMatchedRequestIds = [];
+    string[] consentConstrainedRequestIds = [];
+
+    foreach json param in <json[]>parameterVal {
+        map<json> paramMap = check param.ensureType();
+        json nameVal = paramMap["name"];
+        if nameVal !is string {
+            continue;
+        }
+        string paramName = nameVal;
+
+        if paramName == "MatchedMembers" || paramName == "NonMatchedMembers" || paramName == "ConsentConstrainedMembers" {
+            json resourceVal = paramMap["resource"];
+            if resourceVal !is map<json> {
+                continue;
+            }
+            map<json> groupMap = check resourceVal.ensureType();
+
+            // Extract Group id (only for MatchedMembers)
+            if paramName == "MatchedMembers" {
+                json groupId = groupMap["id"];
+                if groupId is string {
+                    matchedGroupId = groupId;
+                }
+            }
+
+            // Extract contained patients to correlate back to requestIds
+            json[] contained = [];
+            json containedVal = groupMap["contained"];
+            if containedVal is json[] {
+                contained = containedVal;
+            }
+
+            // Build a lookup: contained patient id -> identifier values
+            map<string[]> containedIdToIdentifiers = {};
+            foreach json containedResource in contained {
+                map<json> containedMap = check containedResource.ensureType();
+                json containedId = containedMap["id"];
+                if containedId !is string {
+                    continue;
+                }
+                json[] identifiers = [];
+                json identifierVal = containedMap["identifier"];
+                if identifierVal is json[] {
+                    identifiers = identifierVal;
+                }
+                string[] values = [];
+                foreach json identifier in identifiers {
+                    map<json> identifierMap = check identifier.ensureType();
+                    json idValue = identifierMap["value"];
+                    if idValue is string {
+                        values.push(idValue);
+                    }
+                }
+                containedIdToIdentifiers[containedId] = values;
+            }
+
+            // Walk member[] entries and correlate via contained patient identifiers
+            json memberVal = groupMap["member"];
+            if memberVal !is json[] {
+                continue;
+            }
+
+            foreach json member in <json[]>memberVal {
+                map<json> memberMap = check member.ensureType();
+
+                // The match-parameters extension is on member[].entity.extension, not member[].extension
+                string containedRef = "";
+                json entityVal = memberMap["entity"];
+                if entityVal is map<json> {
+                    map<json> entityMap = check entityVal.ensureType();
+                    json extensionVal = entityMap["extension"];
+                    if extensionVal is json[] {
+                        foreach json ext in extensionVal {
+                            map<json> extMap = check ext.ensureType();
+                            json urlVal = extMap["url"];
+                            if urlVal is string && urlVal.includes("match-parameters") {
+                                json valueRefVal = extMap["valueReference"];
+                                if valueRefVal is map<json> {
+                                    map<json> valueRefMap = check valueRefVal.ensureType();
+                                    json refVal = valueRefMap["reference"];
+                                    if refVal is string {
+                                        // reference is "#containedId" e.g. "#1"
+                                        containedRef = refVal.startsWith("#") ? refVal.substring(1) : refVal;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Find requestId by matching identifier values of the contained patient
+                string[] identifierValues = containedIdToIdentifiers[containedRef] ?: [];
+                string requestId = "";
+                foreach string idValue in identifierValues {
+                    if memberIdToRequestIdMap.hasKey(idValue) {
+                        requestId = memberIdToRequestIdMap.get(idValue);
+                        break;
+                    }
+                }
+
+                if requestId == "" {
+                    log:printWarn("Could not correlate bulk match member to a requestId",
+                        containedRef = containedRef);
+                    continue;
+                }
+
+                if paramName == "MatchedMembers" {
+                    matchedRequestIds.push(requestId);
+                } else if paramName == "NonMatchedMembers" {
+                    nonMatchedRequestIds.push(requestId);
+                } else {
+                    consentConstrainedRequestIds.push(requestId);
+                }
+            }
+        }
+    }
+
+    return {
+        matchedGroupId,
+        matchedRequestIds,
+        nonMatchedRequestIds,
+        consentConstrainedRequestIds
+    };
+}

--- a/bulk-export-client/bulk_match_utils.bal
+++ b/bulk-export-client/bulk_match_utils.bal
@@ -3,6 +3,10 @@
 
 import ballerina/http;
 import ballerina/log;
+import ballerinax/health.fhir.r4;
+import ballerinax/health.fhir.r4.davincihrex100 as hrex100;
+import ballerinax/health.fhir.r4.davincipdex220;
+import ballerinax/health.fhir.r4.international401;
 
 # Build Parameters JSON for POST /Group/$bulk-member-match.
 # Fetches each member's Patient from the local FHIR server and wraps it in a MemberBundle.
@@ -15,135 +19,127 @@ public isolated function buildBulkMemberMatchParams(
     http:Client fhirClient
 ) returns BulkMatchParamsResult|error {
 
-    json[] memberBundles = [];
+    davincipdex220:PDexMultiMemberMatchRequestParametersParameter[] memberBundles = [];
     map<string> memberIdToRequestIdMap = {};
 
     foreach PayerDataExchangeRequest request in requests {
         string memberId = request.memberId;
         string requestId = request.requestId ?: "";
 
-        // 1. Fetch Patient from local FHIR server
+        // 1. Fetch Patient from local FHIR server and parse into typed record
         json|error patientResult = fhirClient->get("/Patient/" + memberId);
         if patientResult is error {
             log:printError("Failed to fetch patient for bulk match", patientResult, memberId = memberId);
             return error("Failed to fetch patient details for member: " + memberId);
         }
-        map<json> patientMap = check patientResult.ensureType();
+        hrex100:HRexPatientDemographics fullPatient = check patientResult.cloneWithType(hrex100:HRexPatientDemographics);
 
-        // 2. Build MemberPatient JSON — keep only required demographic fields
-        map<json> memberPatient = {
-            "resourceType": "Patient",
-            "id": memberId
+        // 2. Build MemberPatient — demographic fields defined by HRex patient-demographics profile
+        hrex100:HRexPatientDemographics memberPatient = {
+            id: memberId,
+            identifier: fullPatient.identifier,
+            name: fullPatient.name,
+            address: fullPatient.address,
+            telecom: fullPatient.telecom,
+            gender: fullPatient.gender,
+            birthDate: fullPatient.birthDate
         };
-        foreach string 'field in ["identifier", "name", "address", "telecom", "gender", "birthDate"] {
-            if patientMap.hasKey('field) {
-                memberPatient['field] = patientMap.get('field);
-            }
-        }
 
         // 3. Build part[] array for the MemberBundle
-        json[] parts = [
-            {"name": "MemberPatient", "resource": memberPatient}
+        international401:ParametersParameter[] parts = [
+            {name: "MemberPatient", 'resource: memberPatient}
         ];
 
         // 4. CoverageToMatch (only if oldCoverageId is provided)
         if request.oldCoverageId != () {
-            json coverageToMatch = {
-                "resourceType": "Coverage",
-                "id": request.oldCoverageId ?: "",
-                "status": "active",
-                "subscriberId": memberId,
-                "beneficiary": {"reference": "Patient/" + memberId},
-                "payor": [{"display": request.oldPayerName}]
+            hrex100:HRexCoverage coverageToMatch = {
+                id: request.oldCoverageId ?: "",
+                status: "active",
+                subscriberId: memberId,
+                beneficiary: {reference: "Patient/" + memberId},
+                payor: [{display: request.oldPayerName}]
             };
-            parts.push({"name": "CoverageToMatch", "resource": coverageToMatch});
+            parts.push({name: "CoverageToMatch", 'resource: coverageToMatch});
         }
 
         // 5. CoverageToLink (always present — links to new payer)
-        json coverageToLink = {
-            "resourceType": "Coverage",
-            "status": "active",
-            "subscriberId": memberId,
-            "beneficiary": {"reference": "Patient/" + memberId},
-            "payor": [{"display": clientServiceConfig.newPayerName}]
+        hrex100:HRexCoverage coverageToLink = {
+            status: "active",
+            subscriberId: memberId,
+            beneficiary: {reference: "Patient/" + memberId},
+            payor: [{display: clientServiceConfig.newPayerName}]
         };
-        parts.push({"name": "CoverageToLink", "resource": coverageToLink});
+        parts.push({name: "CoverageToLink", 'resource: coverageToLink});
 
         // 6. Consent (if consent field is set on the request)
         if request.consent != () {
-            json consent = {
-                "resourceType": "Consent",
-                "status": "active",
-                "scope": {
-                    "coding": [{"system": "http://terminology.hl7.org/CodeSystem/consentscope", "code": "patient-privacy"}]
-                },
-                "category": [
-                    {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "IDSCL"}]}
-                ],
-                "patient": {"reference": "Patient/" + memberId},
-                "performer": [{"reference": "Patient/" + memberId}],
-                "sourceReference": {"reference": "http://example.org/DocumentReference/someconsent"},
-                "policy": [{"uri": "http://hl7.org/fhir/us/davinci-hrex/StructureDefinition-hrex-consent.html#regular"}],
-                "provision": {
-                    "type": "permit",
-                    "period": {
-                        "start": request.coverageStartDate,
-                        "end": request.coverageEndDate
+            hrex100:HRexConsent consent = {
+                status: "active",
+                patient: {reference: "Patient/" + memberId},
+                performer: [{reference: "Patient/" + memberId}],
+                scope: {coding: [{}]},
+                category: [{
+                    coding: [{
+                        system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                        code: "IDSCL"
+                    }]
+                }],
+                sourceReference: {reference: "http://example.org/DocumentReference/someconsent"},
+                policy: [{uri: "http://hl7.org/fhir/us/davinci-hrex/StructureDefinition-hrex-consent.html#regular"}],
+                provision: {
+                    'type: "permit",
+                    period: {
+                        'start: request.coverageStartDate,
+                        'end: request.coverageEndDate
                     },
-                    "actor": [
+                    actor: [
                         {
-                            "role": {
-                                "coding": [{"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type", "code": "performer"}]
-                            },
-                            "reference": {
-                                "identifier": {"system": "http://hl7.org/fhir/sid/us-npi", "value": request.payerId},
-                                "display": request.oldPayerName
+                            role: {coding: [{
+                                system: "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                                code: "performer"
+                            }]},
+                            reference: {
+                                identifier: {system: "http://hl7.org/fhir/sid/us-npi", value: request.payerId},
+                                display: request.oldPayerName
                             }
                         },
                         {
-                            "role": {
-                                "coding": [{"system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType", "code": "IRCP"}]
-                            },
-                            "reference": {
-                                "identifier": {"system": "http://hl7.org/fhir/sid/us-npi", "value": clientServiceConfig.newPayerNpi},
-                                "display": clientServiceConfig.newPayerName
+                            role: {coding: [{
+                                system: "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                                code: "IRCP"
+                            }]},
+                            reference: {
+                                identifier: {system: "http://hl7.org/fhir/sid/us-npi", value: clientServiceConfig.newPayerNpi},
+                                display: clientServiceConfig.newPayerName
                             }
                         }
                     ],
-                    "action": [
-                        {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/consentaction", "code": "disclose"}]}
-                    ]
+                    action: [{coding: [{}]}]
                 }
             };
-            parts.push({"name": "Consent", "resource": consent});
+            parts.push({name: "Consent", 'resource: consent});
         }
 
         // 7. Wrap in MemberBundle
-        memberBundles.push({"name": "MemberBundle", "part": parts});
+        memberBundles.push({name: "MemberBundle", part: parts});
 
         // 8. Track correlation — index by memberId AND by every patient identifier value.
         //    The old payer echoes back our submitted identifier values on the contained patients
         //    in the response Group, so we need those values as lookup keys too.
         memberIdToRequestIdMap[memberId] = requestId;
-        json patientIdentifiers = patientMap["identifier"];
-        if patientIdentifiers is json[] {
-            foreach json idEntry in patientIdentifiers {
-                if idEntry is map<json> {
-                    json idValue = idEntry["value"];
-                    if idValue is string && idValue != "" {
-                        memberIdToRequestIdMap[idValue] = requestId;
-                    }
-                }
+        foreach r4:Identifier identifier in (fullPatient.identifier ?: []) {
+            string? idValue = identifier.value;
+            if idValue is string && idValue != "" {
+                memberIdToRequestIdMap[idValue] = requestId;
             }
         }
     }
 
-    json params = {
-        "resourceType": "Parameters",
-        "parameter": memberBundles
+    davincipdex220:PDexMultiMemberMatchRequestParameters params = {
+        'parameter: memberBundles
     };
 
-    return {params, memberIdToRequestIdMap};
+    return {params: params.toJson(), memberIdToRequestIdMap};
 }
 
 # Parse the 200 response from $bulk-member-match polling.
@@ -157,133 +153,89 @@ public isolated function extractBulkMatchResult(
     map<string> memberIdToRequestIdMap
 ) returns BulkMatchResponseResult|error {
 
-    map<json> payloadMap = check responsePayload.ensureType();
-    json resourceTypeVal = payloadMap["resourceType"];
-    if resourceTypeVal !is string || resourceTypeVal != "Parameters" {
-        return error("Expected Parameters resource in bulk match response");
-    }
-
-    json parameterVal = payloadMap["parameter"];
-    if parameterVal !is json[] {
-        return error("Expected parameter array in bulk match response");
-    }
+    davincipdex220:PDexMultiMemberMatchResponseParameters response =
+        check responsePayload.cloneWithType(davincipdex220:PDexMultiMemberMatchResponseParameters);
 
     string matchedGroupId = "";
     string[] matchedRequestIds = [];
     string[] nonMatchedRequestIds = [];
     string[] consentConstrainedRequestIds = [];
 
-    foreach json param in <json[]>parameterVal {
-        map<json> paramMap = check param.ensureType();
-        json nameVal = paramMap["name"];
-        if nameVal !is string {
+    foreach davincipdex220:PDexMultiMemberMatchResponseParametersParameter param in response.'parameter {
+        r4:Resource? groupResource = param.'resource;
+        if groupResource is () {
             continue;
         }
-        string paramName = nameVal;
 
-        if paramName == "MatchedMembers" || paramName == "NonMatchedMembers" || paramName == "ConsentConstrainedMembers" {
-            json resourceVal = paramMap["resource"];
-            if resourceVal !is map<json> {
+        international401:Group|error groupResult = groupResource.cloneWithType(international401:Group);
+        if groupResult is error {
+            log:printWarn("Failed to parse Group in bulk match response", groupResult, paramName = param.name);
+            continue;
+        }
+        international401:Group grp = groupResult;
+
+        if param.name == "MatchedMembers" {
+            matchedGroupId = grp.id ?: "";
+        }
+
+        // Build a lookup: contained patient id -> identifier values
+        map<string[]> containedIdToIdentifiers = {};
+        foreach r4:Resource containedResource in (grp.contained ?: []) {
+            international401:Patient|error ptResult = containedResource.cloneWithType(international401:Patient);
+            if ptResult is error {
                 continue;
             }
-            map<json> groupMap = check resourceVal.ensureType();
-
-            // Extract Group id (only for MatchedMembers)
-            if paramName == "MatchedMembers" {
-                json groupId = groupMap["id"];
-                if groupId is string {
-                    matchedGroupId = groupId;
-                }
-            }
-
-            // Extract contained patients to correlate back to requestIds
-            json[] contained = [];
-            json containedVal = groupMap["contained"];
-            if containedVal is json[] {
-                contained = containedVal;
-            }
-
-            // Build a lookup: contained patient id -> identifier values
-            map<string[]> containedIdToIdentifiers = {};
-            foreach json containedResource in contained {
-                map<json> containedMap = check containedResource.ensureType();
-                json containedId = containedMap["id"];
-                if containedId !is string {
-                    continue;
-                }
-                json[] identifiers = [];
-                json identifierVal = containedMap["identifier"];
-                if identifierVal is json[] {
-                    identifiers = identifierVal;
-                }
-                string[] values = [];
-                foreach json identifier in identifiers {
-                    map<json> identifierMap = check identifier.ensureType();
-                    json idValue = identifierMap["value"];
-                    if idValue is string {
-                        values.push(idValue);
-                    }
-                }
-                containedIdToIdentifiers[containedId] = values;
-            }
-
-            // Walk member[] entries and correlate via contained patient identifiers
-            json memberVal = groupMap["member"];
-            if memberVal !is json[] {
+            string containedId = ptResult.id ?: "";
+            if containedId == "" {
                 continue;
             }
+            string[] values = [];
+            foreach r4:Identifier identifier in (ptResult.identifier ?: []) {
+                string? idValue = identifier.value;
+                if idValue is string && idValue != "" {
+                    values.push(idValue);
+                }
+            }
+            containedIdToIdentifiers[containedId] = values;
+        }
 
-            foreach json member in <json[]>memberVal {
-                map<json> memberMap = check member.ensureType();
-
-                // The match-parameters extension is on member[].entity.extension, not member[].extension
-                string containedRef = "";
-                json entityVal = memberMap["entity"];
-                if entityVal is map<json> {
-                    map<json> entityMap = check entityVal.ensureType();
-                    json extensionVal = entityMap["extension"];
-                    if extensionVal is json[] {
-                        foreach json ext in extensionVal {
-                            map<json> extMap = check ext.ensureType();
-                            json urlVal = extMap["url"];
-                            if urlVal is string && urlVal.includes("match-parameters") {
-                                json valueRefVal = extMap["valueReference"];
-                                if valueRefVal is map<json> {
-                                    map<json> valueRefMap = check valueRefVal.ensureType();
-                                    json refVal = valueRefMap["reference"];
-                                    if refVal is string {
-                                        // reference is "#containedId" e.g. "#1"
-                                        containedRef = refVal.startsWith("#") ? refVal.substring(1) : refVal;
-                                    }
-                                }
-                            }
+        // Walk member[] entries and correlate via contained patient identifiers
+        foreach international401:GroupMember member in (grp.member ?: []) {
+            // The match-parameters extension is on member.entity.extension
+            string containedRef = "";
+            foreach r4:Extension ext in (member.entity.extension ?: []) {
+                if ext is r4:ReferenceExtension {
+                    if ext.url.includes("match-parameters") {
+                        string? refVal = ext.valueReference.reference;
+                        if refVal is string {
+                            containedRef = refVal.startsWith("#") ? refVal.substring(1) : refVal;
                         }
-                    }
-                }
-
-                // Find requestId by matching identifier values of the contained patient
-                string[] identifierValues = containedIdToIdentifiers[containedRef] ?: [];
-                string requestId = "";
-                foreach string idValue in identifierValues {
-                    if memberIdToRequestIdMap.hasKey(idValue) {
-                        requestId = memberIdToRequestIdMap.get(idValue);
                         break;
                     }
                 }
+            }
 
-                if requestId == "" {
-                    log:printWarn("Could not correlate bulk match member to a requestId",
-                        containedRef = containedRef);
-                    continue;
+            string[] identifierValues = containedIdToIdentifiers[containedRef] ?: [];
+            string requestId = "";
+            foreach string idValue in identifierValues {
+                if memberIdToRequestIdMap.hasKey(idValue) {
+                    requestId = memberIdToRequestIdMap.get(idValue);
+                    break;
                 }
+            }
 
-                if paramName == "MatchedMembers" {
-                    matchedRequestIds.push(requestId);
-                } else if paramName == "NonMatchedMembers" {
-                    nonMatchedRequestIds.push(requestId);
-                } else {
-                    consentConstrainedRequestIds.push(requestId);
-                }
+            if requestId == "" {
+                log:printWarn("Could not correlate bulk match member to a requestId",
+                    containedRef = containedRef);
+                continue;
+            }
+
+            if param.name == "MatchedMembers" {
+                matchedRequestIds.push(requestId);
+            } else if param.name == "NonMatchedMembers" {
+                nonMatchedRequestIds.push(requestId);
+            } else {
+                consentConstrainedRequestIds.push(requestId);
             }
         }
     }

--- a/bulk-export-client/bulk_match_utils.bal
+++ b/bulk-export-client/bulk_match_utils.bal
@@ -77,7 +77,7 @@ public isolated function buildBulkMemberMatchParams(
                 status: "active",
                 patient: {reference: "Patient/" + memberId},
                 performer: [{reference: "Patient/" + memberId}],
-                scope: {coding: [{}]},
+                scope: {coding: [{system: "http://terminology.hl7.org/CodeSystem/consentscope", code: "patient-privacy"}]},
                 category: [{
                     coding: [{
                         system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
@@ -114,7 +114,7 @@ public isolated function buildBulkMemberMatchParams(
                             }
                         }
                     ],
-                    action: [{coding: [{}]}]
+                    action: [{coding: [{system: "http://terminology.hl7.org/CodeSystem/consentaction", code: "disclose"}]}]
                 }
             };
             parts.push({name: "Consent", 'resource: consent});

--- a/bulk-export-client/bulk_match_utils.bal
+++ b/bulk-export-client/bulk_match_utils.bal
@@ -1,5 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 import ballerina/http;
 import ballerina/log;

--- a/bulk-export-client/db_client.bal
+++ b/bulk-export-client/db_client.bal
@@ -283,6 +283,10 @@ public isolated function linkRequestsToBulkJob(string[] requestIds, string jobId
             log:printError("Database error linking request to bulk job", 'error = result, requestId = requestId);
             return error("An internal error occurred while linking request " + requestId + " to bulk export job.");
         }
+        if result.affectedRowCount == 0 {
+            log:printError("No rows updated when linking request to bulk job; requestId not found", requestId = requestId, jobId = jobId);
+            return error("Request not found: " + requestId);
+        }
     }
     return "Requests linked to bulk export job successfully";
 }

--- a/bulk-export-client/db_client.bal
+++ b/bulk-export-client/db_client.bal
@@ -60,19 +60,20 @@ public isolated function getPayerDataExchangeRequests(int 'limit = 10, int offse
         return error("An internal error occurred while fetching the data.");
     }
 
-    sql:ParameterizedQuery query = `SELECT 
-                                        r.request_id AS requestId, 
-                                        r.payer_id AS payerId, 
-                                        r.member_id AS memberId, 
-                                        p.name AS oldPayerName, 
-                                        p.state AS oldPayerState, 
-                                        r.old_coverage_id AS oldCoverageId, 
-                                        r.coverage_start_date AS coverageStartDate, 
-                                        r.coverage_end_date AS coverageEndDate,
-                                        r.bulk_data_sync_status AS bulkDataSyncStatus, 
-                                        r.consent_status AS consent, 
-                                        r.created_at AS createdDate, 
-                                        r.export_summary AS exportSummary
+    sql:ParameterizedQuery query = `SELECT
+                                        r.request_id AS requestId,
+                                        r.payer_id AS payerId,
+                                        r.member_id AS memberId,
+                                        p.name AS oldPayerName,
+                                        p.state AS oldPayerState,
+                                        r.old_coverage_id AS oldCoverageId,
+                                        CAST(r.coverage_start_date AS CHAR) AS coverageStartDate,
+                                        CAST(r.coverage_end_date AS CHAR) AS coverageEndDate,
+                                        r.bulk_data_sync_status AS bulkDataSyncStatus,
+                                        r.consent_status AS consent,
+                                        DATE_FORMAT(r.created_at, '%Y-%m-%dT%TZ') AS createdDate,
+                                        r.export_summary AS exportSummary,
+                                        r.bulk_export_job_id AS bulkExportJobId
                                     FROM payer_data_exchange_requests r
                                     LEFT JOIN payers p ON r.payer_id = p.id
                                     ORDER BY CASE WHEN r.bulk_data_sync_status = 'PENDING' THEN 1 ELSE 2 END, r.created_at DESC
@@ -106,19 +107,20 @@ public isolated function updatePayerDataExchangeRequestStatus(string requestId, 
 }
 
 public isolated function getPayerDataExchangeRequest(string requestId) returns PayerDataExchangeRequest|error {
-    sql:ParameterizedQuery query = `SELECT 
-                                        r.request_id AS requestId, 
-                                        r.payer_id AS payerId, 
-                                        r.member_id AS memberId, 
-                                        p.name AS oldPayerName, 
-                                        p.state AS oldPayerState, 
-                                        r.old_coverage_id AS oldCoverageId, 
-                                        r.coverage_start_date AS coverageStartDate, 
-                                        r.coverage_end_date AS coverageEndDate, 
-                                        r.bulk_data_sync_status AS bulkDataSyncStatus, 
-                                        r.consent_status AS consent, 
-                                        r.created_at AS createdDate, 
-                                        r.export_summary AS exportSummary
+    sql:ParameterizedQuery query = `SELECT
+                                        r.request_id AS requestId,
+                                        r.payer_id AS payerId,
+                                        r.member_id AS memberId,
+                                        p.name AS oldPayerName,
+                                        p.state AS oldPayerState,
+                                        r.old_coverage_id AS oldCoverageId,
+                                        CAST(r.coverage_start_date AS CHAR) AS coverageStartDate,
+                                        CAST(r.coverage_end_date AS CHAR) AS coverageEndDate,
+                                        r.bulk_data_sync_status AS bulkDataSyncStatus,
+                                        r.consent_status AS consent,
+                                        DATE_FORMAT(r.created_at, '%Y-%m-%dT%TZ') AS createdDate,
+                                        r.export_summary AS exportSummary,
+                                        r.bulk_export_job_id AS bulkExportJobId
                                     FROM payer_data_exchange_requests r
                                     LEFT JOIN payers p ON r.payer_id = p.id
                                     WHERE r.request_id = ${requestId}`;
@@ -200,6 +202,8 @@ public isolated function getPayerConfig(string payerId) returns PayerConfig|erro
         }
     }
 
+    boolean authEnabled = result.clientId.trim().length() > 0 && result.clientSecret.trim().length() > 0;
+
     PayerConfig config = {
         payerId: result.payerId,
         payerName: result.payerName,
@@ -209,7 +213,105 @@ public isolated function getPayerConfig(string payerId) returns PayerConfig|erro
         clientSecret: result.clientSecret,
         scopes: scopes,
         fileServerUrl: (),
-        authEnabled: true
+        authEnabled: authEnabled
     };
     return config;
+}
+
+// ============================================================================
+// Bulk Export Job DB Functions
+// ============================================================================
+
+public isolated function insertBulkExportJob(BulkExportJob job) returns string|error {
+    sql:ParameterizedQuery query = `INSERT INTO bulk_export_jobs (job_id, payer_id, status)
+                                    VALUES (${job.jobId}, ${job.payerId}, ${job.status})`;
+    sql:ExecutionResult|sql:Error result = dbClient->execute(query);
+    if result is sql:ExecutionResult {
+        if result.affectedRowCount > 0 {
+            return job.jobId;
+        }
+        return error("Failed to insert bulk export job.");
+    } else {
+        log:printError("Database error during bulk export job insert", 'error = result);
+        return error("An internal error occurred while creating the bulk export job.");
+    }
+}
+
+public isolated function getBulkExportJob(string jobId) returns BulkExportJob|error {
+    sql:ParameterizedQuery query = `SELECT
+                                        job_id AS jobId,
+                                        payer_id AS payerId,
+                                        status,
+                                        created_at AS createdAt,
+                                        completed_at AS completedAt
+                                    FROM bulk_export_jobs
+                                    WHERE job_id = ${jobId}`;
+    BulkExportJob|sql:Error result = dbClient->queryRow(query);
+    if result is sql:Error {
+        log:printError("Database error fetching bulk export job", 'error = result);
+        return error("An internal error occurred while fetching the bulk export job.");
+    }
+    return result;
+}
+
+public isolated function updateBulkExportJobStatus(string jobId, string status) returns string|error {
+    sql:ParameterizedQuery query;
+    if status == "COMPLETED" || status == "FAILED" {
+        query = `UPDATE bulk_export_jobs SET status = ${status}, completed_at = CURRENT_TIMESTAMP WHERE job_id = ${jobId}`;
+    } else {
+        query = `UPDATE bulk_export_jobs SET status = ${status} WHERE job_id = ${jobId}`;
+    }
+    sql:ExecutionResult|sql:Error result = dbClient->execute(query);
+    if result is sql:ExecutionResult {
+        if result.affectedRowCount > 0 {
+            return "Bulk export job status updated successfully";
+        }
+        return error("Failed to update bulk export job status. Job ID not found.");
+    } else {
+        log:printError("Database error during bulk export job status update", 'error = result);
+        return error("An internal error occurred while updating the bulk export job status.");
+    }
+}
+
+public isolated function linkRequestsToBulkJob(string[] requestIds, string jobId) returns string|error {
+    foreach string requestId in requestIds {
+        sql:ParameterizedQuery query = `UPDATE payer_data_exchange_requests
+                                        SET bulk_export_job_id = ${jobId}
+                                        WHERE request_id = ${requestId}`;
+        sql:ExecutionResult|sql:Error result = dbClient->execute(query);
+        if result is sql:Error {
+            log:printError("Database error linking request to bulk job", 'error = result, requestId = requestId);
+            return error("An internal error occurred while linking request " + requestId + " to bulk export job.");
+        }
+    }
+    return "Requests linked to bulk export job successfully";
+}
+
+public isolated function getRequestsByBulkJobId(string jobId) returns PayerDataExchangeRequest[]|error {
+    sql:ParameterizedQuery query = `SELECT
+                                        r.request_id AS requestId,
+                                        r.payer_id AS payerId,
+                                        r.member_id AS memberId,
+                                        p.name AS oldPayerName,
+                                        p.state AS oldPayerState,
+                                        r.old_coverage_id AS oldCoverageId,
+                                        CAST(r.coverage_start_date AS CHAR) AS coverageStartDate,
+                                        CAST(r.coverage_end_date AS CHAR) AS coverageEndDate,
+                                        r.bulk_data_sync_status AS bulkDataSyncStatus,
+                                        r.consent_status AS consent,
+                                        r.created_at AS createdDate,
+                                        r.export_summary AS exportSummary,
+                                        r.bulk_export_job_id AS bulkExportJobId
+                                    FROM payer_data_exchange_requests r
+                                    LEFT JOIN payers p ON r.payer_id = p.id
+                                    WHERE r.bulk_export_job_id = ${jobId}
+                                    ORDER BY r.created_at DESC`;
+    stream<PayerDataExchangeRequest, sql:Error?> resultStream = dbClient->query(query);
+    PayerDataExchangeRequest[]|error requests = from PayerDataExchangeRequest request in resultStream
+        select request;
+    if requests is error {
+        log:printError("Database error fetching requests by bulk job ID", 'error = requests);
+        return error("An internal error occurred while fetching requests for the bulk export job.");
+    }
+    return requests;
 }

--- a/bulk-export-client/db_client.bal
+++ b/bulk-export-client/db_client.bal
@@ -291,6 +291,19 @@ public isolated function linkRequestsToBulkJob(string[] requestIds, string jobId
     return "Requests linked to bulk export job successfully";
 }
 
+public isolated function unlinkRequestsFromBulkJob(string[] requestIds) returns error? {
+    foreach string requestId in requestIds {
+        sql:ParameterizedQuery query = `UPDATE payer_data_exchange_requests
+                                        SET bulk_export_job_id = NULL
+                                        WHERE request_id = ${requestId}`;
+        sql:ExecutionResult|sql:Error result = dbClient->execute(query);
+        if result is sql:Error {
+            log:printError("Database error unlinking request from bulk job", 'error = result, requestId = requestId);
+            return error("An internal error occurred while unlinking request " + requestId + " from bulk export job.");
+        }
+    }
+}
+
 public isolated function getRequestsByBulkJobId(string jobId) returns PayerDataExchangeRequest[]|error {
     sql:ParameterizedQuery query = `SELECT
                                         r.request_id AS requestId,

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -322,7 +322,7 @@ isolated service /pdex on bulkExportListener {
     // @return batchId and status, or error.
     isolated resource function post 'trigger\-bulk\-data\-exchange(
         @http:Payload TriggerBulkDataExchangeRequest payload
-    ) returns http:Response|http:BadRequest|http:Conflict|error {
+    ) returns http:Response|http:BadRequest|http:Conflict|http:InternalServerError|error {
 
         string[] requestIds = payload.requestIds;
         if requestIds.length() == 0 {
@@ -332,7 +332,12 @@ isolated service /pdex on bulkExportListener {
         // 1. Load and validate all requests
         PayerDataExchangeRequest[] requests = [];
         foreach string reqId in requestIds {
-            PayerDataExchangeRequest req = check getPayerDataExchangeRequest(reqId);
+            PayerDataExchangeRequest|error reqResult = getPayerDataExchangeRequest(reqId);
+            if reqResult is error {
+                log:printError("Error occurred while retrieving payer data exchange request", reqResult, requestId = reqId);
+                return <http:InternalServerError>{body: {message: "Unable to retrieve request", requestId: reqId}};
+            }
+            PayerDataExchangeRequest req = reqResult;
             if !(req.consent ?: "").equalsIgnoreCaseAscii("APPROVED") {
                 return <http:BadRequest>{body: {
                     message: "Consent not approved for requestId: " + reqId,
@@ -460,7 +465,7 @@ isolated service /pdex on bulkExportListener {
         PayerDataExchangeRequest[]|error requests = getRequestsByBulkJobId(jobId);
         if requests is error {
             log:printError("Error fetching requests for bulk job", requests, jobId = jobId);
-            return requests;
+            return error("Internal server error while retrieving requests for bulk job");
         }
         return {job: job, requests: requests};
     }

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -16,6 +16,7 @@
 import ballerina/http;
 import ballerina/log;
 import ballerina/url;
+import ballerina/uuid;
 import ballerinax/health.fhir.r4.international401;
 
 public listener http:Listener bulkExportListener = new (8091);
@@ -153,7 +154,7 @@ isolated service /pdex on bulkExportListener {
             clientSecret: payerConfig.clientSecret,
             scopes: payerConfig.scopes,
             fileServerUrl: payerConfig.fileServerUrl,
-            authEnabled: true
+            authEnabled: payerConfig.authEnabled
         };
 
         http:Client|error httpClient = createHttpClient(serverConfig);
@@ -251,7 +252,7 @@ isolated service /pdex on bulkExportListener {
 
         foreach string resType in resourcesToCheck {
             string encodedMemberId = check url:encode(memberId, "UTF-8");
-            string path = string `/${resType}?patient=${encodedMemberId}&_tag=http://wso2.com/fhir/pdex-source|old-payer-data`;
+            string path = string `/${resType}?patient=${encodedMemberId}`;
             log:printDebug("Querying resource type for synced data.", resourceType = resType, path = path);
             http:Response|http:ClientError resp = fhirClient->get(path);
             if resp is http:Response && resp.statusCode == 200 {
@@ -281,5 +282,181 @@ isolated service /pdex on bulkExportListener {
         log:printDebug("Completed synced data fetch.", resultCount = results.length().toString());
 
         return results;
+    }
+
+    // Resource function to reset a stuck IN_PROGRESS request back to PENDING.
+    //
+    // @param requestId - The ID of the request to reset.
+    // @return The response indicating the success or failure of the operation.
+    isolated resource function post 'pdex\-data\-requests/[string requestId]/reset()
+            returns json|http:BadRequest|http:NotFound|error {
+        log:printDebug("Reset request invoked.", requestId = requestId);
+        PayerDataExchangeRequest|error req = getPayerDataExchangeRequest(requestId);
+        if req is error {
+            return <http:NotFound>{body: {message: "Request not found", requestId: requestId}};
+        }
+        if req.bulkDataSyncStatus != "IN_PROGRESS" {
+            return <http:BadRequest>{body: {
+                message: "Only IN_PROGRESS requests can be reset",
+                requestId: requestId,
+                currentStatus: req.bulkDataSyncStatus
+            }};
+        }
+        string|error result = updatePayerDataExchangeRequestStatus(requestId, "PENDING");
+        if result is error {
+            log:printError("Failed to reset request status to PENDING", result, requestId = requestId);
+            return result;
+        }
+        log:printInfo("Request reset to PENDING.", requestId = requestId);
+        return {message: "Request reset to PENDING", requestId: requestId};
+    }
+
+    // Resource function to trigger bulk payer data exchange using $bulk-member-match.
+    //
+    // @param payload - List of requestIds to batch into a single $bulk-member-match call.
+    // @return batchId and status, or error.
+    isolated resource function post 'trigger\-bulk\-data\-exchange(
+        @http:Payload TriggerBulkDataExchangeRequest payload
+    ) returns http:Response|http:BadRequest|http:Conflict|error {
+
+        string[] requestIds = payload.requestIds;
+        if requestIds.length() == 0 {
+            return <http:BadRequest>{body: {message: "At least one requestId is required"}};
+        }
+
+        // 1. Load and validate all requests
+        PayerDataExchangeRequest[] requests = [];
+        foreach string reqId in requestIds {
+            PayerDataExchangeRequest req = check getPayerDataExchangeRequest(reqId);
+            if !(req.consent ?: "").equalsIgnoreCaseAscii("APPROVED") {
+                return <http:BadRequest>{body: {
+                    message: "Consent not approved for requestId: " + reqId,
+                    requestId: reqId
+                }};
+            }
+            if req.bulkDataSyncStatus == "IN_PROGRESS" || req.bulkDataSyncStatus == "COMPLETED" {
+                return <http:Conflict>{body: {
+                    message: "Request " + reqId + " is already " + (req.bulkDataSyncStatus ?: "processed"),
+                    requestId: reqId,
+                    currentStatus: req.bulkDataSyncStatus
+                }};
+            }
+            requests.push(req);
+        }
+
+        // 2. Validate all requests belong to same payer
+        string payerId = requests[0].payerId;
+        foreach PayerDataExchangeRequest req in requests {
+            if req.payerId != payerId {
+                return <http:BadRequest>{body: {
+                    message: "All requestIds must belong to the same payer",
+                    requestId: req.requestId ?: ""
+                }};
+            }
+        }
+
+        // 3. Load payer config + build serverConfig
+        PayerConfig payerConfig = check getPayerConfig(payerId);
+        BulkExportServerConfig serverConfig = {
+            baseUrl: payerConfig.baseUrl,
+            tokenUrl: payerConfig.tokenUrl,
+            clientId: payerConfig.clientId,
+            clientSecret: payerConfig.clientSecret,
+            scopes: payerConfig.scopes,
+            fileServerUrl: payerConfig.fileServerUrl,
+            authEnabled: payerConfig.authEnabled
+        };
+
+        // 4. Create HTTP client pointed at old payer, fetch Patient resources from LOCAL FHIR server
+        http:Client httpClient = check createHttpClient(serverConfig);
+
+        // 5. Build bulk member match Parameters JSON
+        BulkMatchParamsResult paramsResult = check buildBulkMemberMatchParams(requests, clientFhirClient);
+
+        // 6. POST to $bulk-member-match (async)
+        http:Response|http:ClientError matchResponse = httpClient->post(
+            "/Group/$bulk-member-match",
+            paramsResult.params,
+            headers = {"Prefer": "respond-async"},
+            mediaType = "application/fhir+json"
+        );
+        if matchResponse is http:ClientError {
+            return error("Error calling $bulk-member-match: " + matchResponse.message());
+        }
+        if matchResponse.statusCode != 202 {
+            return error("$bulk-member-match returned unexpected status: "
+                + matchResponse.statusCode.toString());
+        }
+
+        // 7. Get polling URL from Content-Location header
+        string pollingUrl = check matchResponse.getHeader("content-location");
+
+        // 8. Persist the bulk export job and link requests to it
+        string jobId = uuid:createType1AsString();
+        BulkExportJob newJob = {
+            jobId: jobId,
+            payerId: payerId,
+            status: "INITIATED"
+        };
+        _ = check insertBulkExportJob(newJob);
+        _ = check linkRequestsToBulkJob(requestIds, jobId);
+        _ = check updateBulkExportJobStatus(jobId, "BULK_MATCH_POLLING");
+
+        log:printInfo("$bulk-member-match accepted.",
+            jobId = jobId, pollingUrl = pollingUrl,
+            memberCount = paramsResult.memberIdToRequestIdMap.length());
+        log:printDebug("$bulk-member-match request payload.",
+            jobId = jobId, payload = paramsResult.params.toJsonString());
+
+        // 9. Schedule Stage 1 background polling task
+        _ = check scheduleBulkMatchJob(
+            new BulkMatchPollingTask(
+                jobId,
+                pollingUrl,
+                serverConfig,
+                paramsResult.memberIdToRequestIdMap,
+                requestIds,
+                payerId,
+                requests[0].oldPayerName
+            ),
+            clientServiceConfig.defaultIntervalInSec
+        );
+
+        // 10. Update all requests to BULK_MATCH_SUBMITTED
+        foreach string reqId in requestIds {
+            _ = check updatePayerDataExchangeRequestStatus(reqId, "BULK_MATCH_SUBMITTED");
+        }
+
+        log:printInfo("Bulk member match initiated.", jobId = jobId, requestCount = requestIds.length());
+        string statusUrl = clientServiceConfig.baseUrl + "/pdex/bulk-export-jobs/" + jobId;
+        http:Response resp = new;
+        resp.statusCode = 202;
+        resp.setHeader("Content-Location", statusUrl);
+        resp.setJsonPayload({
+            jobId: jobId,
+            message: "Bulk member match initiated",
+            requestCount: requestIds.length(),
+            statusUrl: statusUrl
+        });
+        return resp;
+    }
+
+    // Resource function to poll bulk export job status.
+    //
+    // @param jobId - The bulk export job ID returned by trigger-bulk-data-exchange.
+    // @return Combined job status and individual request statuses.
+    isolated resource function get 'bulk\-export\-jobs/[string jobId]()
+            returns BulkExportJobStatusResponse|http:NotFound|error {
+        log:printDebug("Fetching bulk export job status.", jobId = jobId);
+        BulkExportJob|error job = getBulkExportJob(jobId);
+        if job is error {
+            return <http:NotFound>{body: {message: "Bulk export job not found", jobId: jobId}};
+        }
+        PayerDataExchangeRequest[]|error requests = getRequestsByBulkJobId(jobId);
+        if requests is error {
+            log:printError("Error fetching requests for bulk job", requests, jobId = jobId);
+            return requests;
+        }
+        return {job: job, requests: requests};
     }
 }

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -167,7 +167,9 @@ isolated service /pdex on bulkExportListener {
             return error("Error creating HTTP client: " + httpClient.message());
         }
 
-        international401:Parameters memberMatchParams = check createMemberMatchParams(request, httpClient);
+        // MemberPatient must be fetched from the LOCAL FHIR server (our own record of the member),
+        // not from the old payer's server.
+        international401:Parameters memberMatchParams = check createMemberMatchParams(request, clientFhirClient);
         log:printDebug("Created member match parameters.", requestId = requestId);
 
         // Call $member-match
@@ -185,7 +187,10 @@ isolated service /pdex on bulkExportListener {
         }
 
         if matchResponse.statusCode < 200 || matchResponse.statusCode >= 300 {
-            log:printError("Member match failed with status: " + matchResponse.statusCode.toString());
+            string|error errBody = matchResponse.getTextPayload();
+            log:printError("Member match failed.",
+                statusCode = matchResponse.statusCode.toString(),
+                body = errBody is string ? errBody : "(no body)");
             error memberMatchError = error("Member match failed");
             string|error dbResult = updatePayerDataExchangeRequestStatus(requestId, "FAILED");
             if dbResult is error {

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -458,7 +458,7 @@ isolated service /pdex on bulkExportListener {
             jobId = jobId, payload = paramsResult.params.toJsonString());
 
         // 9. Schedule Stage 1 background polling task
-        _ = check scheduleBulkMatchJob(
+        error? scheduleErr = scheduleBulkMatchJob(
             new BulkMatchPollingTask(
                 jobId,
                 pollingUrl,
@@ -470,10 +470,25 @@ isolated service /pdex on bulkExportListener {
             ),
             clientServiceConfig.defaultIntervalInSec
         );
+        if scheduleErr is error {
+            log:printError("Failed to schedule bulk match job; compensating", scheduleErr, jobId = jobId);
+            _ = check updateBulkExportJobStatus(jobId, "FAILED");
+            _ = check unlinkRequestsFromBulkJob(requestIds);
+            return <http:InternalServerError>{body: {message: "Failed to schedule bulk match polling"}};
+        }
 
         // 10. Update all requests to BULK_MATCH_SUBMITTED
         foreach string reqId in requestIds {
-            _ = check updatePayerDataExchangeRequestStatus(reqId, "BULK_MATCH_SUBMITTED");
+            string|error submitResult = updatePayerDataExchangeRequestStatus(reqId, "BULK_MATCH_SUBMITTED");
+            if submitResult is error {
+                log:printError("Failed to mark request BULK_MATCH_SUBMITTED; compensating",
+                    submitResult, requestId = reqId, jobId = jobId);
+                _ = check updateBulkExportJobStatus(jobId, "FAILED");
+                foreach string failReqId in requestIds {
+                    _ = check updatePayerDataExchangeRequestStatus(failReqId, "FAILED");
+                }
+                return <http:InternalServerError>{body: {message: "Failed to update request status after scheduling"}};
+            }
         }
 
         log:printInfo("Bulk member match initiated.", jobId = jobId, requestCount = requestIds.length());

--- a/bulk-export-client/pdex_service.bal
+++ b/bulk-export-client/pdex_service.bal
@@ -300,12 +300,24 @@ isolated service /pdex on bulkExportListener {
         if req is error {
             return <http:NotFound>{body: {message: "Request not found", requestId: requestId}};
         }
-        if req.bulkDataSyncStatus != "IN_PROGRESS" {
+        string[] resettableStatuses = ["IN_PROGRESS", "BULK_MATCH_SUBMITTED", "EXPORT_IN_PROGRESS", "SYNCING"];
+        if resettableStatuses.indexOf(req.bulkDataSyncStatus ?: "") == () {
             return <http:BadRequest>{body: {
-                message: "Only IN_PROGRESS requests can be reset",
+                message: "Only in-flight requests can be reset (IN_PROGRESS, BULK_MATCH_SUBMITTED, EXPORT_IN_PROGRESS, SYNCING)",
                 requestId: requestId,
                 currentStatus: req.bulkDataSyncStatus
             }};
+        }
+        // Neutralize any associated background job so polling tasks short-circuit on next tick
+        string? jobId = req.bulkExportJobId;
+        if jobId is string {
+            string|error cancelResult = updateBulkExportJobStatus(jobId, "FAILED");
+            if cancelResult is error {
+                log:printError("Failed to mark bulk job FAILED during reset; proceeding with request reset",
+                    cancelResult, requestId = requestId, jobId = jobId);
+            } else {
+                log:printInfo("Marked bulk job FAILED as part of request reset.", requestId = requestId, jobId = jobId);
+            }
         }
         string|error result = updatePayerDataExchangeRequestStatus(requestId, "PENDING");
         if result is error {
@@ -322,7 +334,7 @@ isolated service /pdex on bulkExportListener {
     // @return batchId and status, or error.
     isolated resource function post 'trigger\-bulk\-data\-exchange(
         @http:Payload TriggerBulkDataExchangeRequest payload
-    ) returns http:Response|http:BadRequest|http:Conflict|http:InternalServerError|error {
+    ) returns http:Response|http:BadRequest|http:Conflict|http:InternalServerError|http:BadGateway|error {
 
         string[] requestIds = payload.requestIds;
         if requestIds.length() == 0 {
@@ -398,19 +410,46 @@ isolated service /pdex on bulkExportListener {
                 + matchResponse.statusCode.toString());
         }
 
-        // 7. Get polling URL from Content-Location header
-        string pollingUrl = check matchResponse.getHeader("content-location");
-
-        // 8. Persist the bulk export job and link requests to it
+        // 7. Persist the bulk export job and link requests to it
         string jobId = uuid:createType1AsString();
         BulkExportJob newJob = {
             jobId: jobId,
             payerId: payerId,
             status: "INITIATED"
         };
-        _ = check insertBulkExportJob(newJob);
-        _ = check linkRequestsToBulkJob(requestIds, jobId);
-        _ = check updateBulkExportJobStatus(jobId, "BULK_MATCH_POLLING");
+        string|error insertResult = insertBulkExportJob(newJob);
+        if insertResult is error {
+            log:printError("Failed to persist bulk export job", insertResult, jobId = jobId);
+            return <http:InternalServerError>{body: {message: "Failed to create bulk export job"}};
+        }
+        string|error linkResult = linkRequestsToBulkJob(requestIds, jobId);
+        if linkResult is error {
+            log:printError("Failed to link requests to bulk job; compensating", linkResult, jobId = jobId);
+            _ = check updateBulkExportJobStatus(jobId, "FAILED");
+            _ = check unlinkRequestsFromBulkJob(requestIds);
+            return <http:InternalServerError>{body: {message: "Failed to link requests to bulk export job"}};
+        }
+        string|error statusResult = updateBulkExportJobStatus(jobId, "BULK_MATCH_POLLING");
+        if statusResult is error {
+            log:printError("Failed to update bulk job status; compensating", statusResult, jobId = jobId);
+            _ = check updateBulkExportJobStatus(jobId, "FAILED");
+            _ = check unlinkRequestsFromBulkJob(requestIds);
+            return <http:InternalServerError>{body: {message: "Failed to update bulk export job status"}};
+        }
+
+        // 8. Validate Content-Location header (required by bulk-data protocol)
+        string|http:HeaderNotFoundError contentLocation = matchResponse.getHeader("content-location");
+        if contentLocation is http:HeaderNotFoundError || contentLocation == "" {
+            log:printError("Upstream did not return Content-Location header; marking job FAILED.", jobId = jobId);
+            _ = check updateBulkExportJobStatus(jobId, "FAILED");
+            foreach string reqId in requestIds {
+                _ = check updatePayerDataExchangeRequestStatus(reqId, "FAILED");
+            }
+            return <http:BadGateway>{body: {
+                message: "Upstream server did not return a Content-Location header as required by the bulk data protocol"
+            }};
+        }
+        string pollingUrl = contentLocation;
 
         log:printInfo("$bulk-member-match accepted.",
             jobId = jobId, pollingUrl = pollingUrl,

--- a/bulk-export-client/pdex_utils.bal
+++ b/bulk-export-client/pdex_utils.bal
@@ -310,7 +310,7 @@ isolated function processNdjsonStream(stream<byte[], io:Error?> byteStream, http
         check from string line in lineStream
             do {
                 json|error resourceJson = line.fromJsonString();
-                if resourceJson is json {
+                if resourceJson is json && resourceJson != null {
                     check processAndInsertResource(resourceJson, fhirClient, context);
                 }
             };
@@ -373,17 +373,32 @@ isolated function processAndInsertResource(json resourceJson, http:Client fhirCl
     meta["tag"] = tag;
     resourceMap["meta"] = meta;
 
-    // Insert (POST for new resource creation)
-    http:Response|http:ClientError resp = fhirClient->post("/" + resourceType, resourceMap, headers = {"Content-Type": "application/fhir+json"});
+    // POST to new payer FHIR server (standard FHIR create — server assigns its own ID).
+    // We read the actual server-assigned ID back from the response body so that the
+    // Provenance target reference uses the real stored ID (avoids FK_REFERENCES_TARGET violation).
+    http:Response|http:ClientError resp = fhirClient->post("/" + resourceType, resourceMap,
+        headers = {"Content-Type": "application/fhir+json"});
     if resp is http:ClientError {
-        log:printError("Error syncing resource " + resourceType + "/" + newId, resp);
+        log:printError("Error syncing resource " + resourceType, resp);
     } else if resp.statusCode == 201 || resp.statusCode == 200 {
-        log:printDebug("Resource synced successfully.", resourceType = resourceType, newId = newId, statusCode = resp.statusCode.toString());
-        // Create Provenance resource
-        check createProvenance(resourceType, newId, context, fhirClient);
-        log:printDebug("Provenance created for synced resource.", resourceType = resourceType, newId = newId);
+        // Extract the server-assigned ID from the response body; fall back to our computed id.
+        string savedId = newId;
+        json|error respBody = resp.getJsonPayload();
+        if respBody is json {
+            map<json>|error respMap = respBody.ensureType();
+            if respMap is map<json> && respMap.hasKey("id") {
+                string|error actualId = respMap.get("id").ensureType(string);
+                if actualId is string {
+                    savedId = actualId;
+                }
+            }
+        }
+        log:printDebug("Resource synced successfully.", resourceType = resourceType,
+            savedId = savedId, statusCode = resp.statusCode.toString());
+        check createProvenance(resourceType, savedId, context, fhirClient);
+        log:printDebug("Provenance created for synced resource.", resourceType = resourceType, savedId = savedId);
     } else {
-        log:printError("Failed to sync resource " + resourceType + "/" + newId + ". Status: " + resp.statusCode.toString());
+        log:printError("Failed to sync resource " + resourceType + ". Status: " + resp.statusCode.toString());
     }
 
     return null;

--- a/bulk-export-client/records.bal
+++ b/bulk-export-client/records.bal
@@ -119,6 +119,7 @@ public type MatchedPatient record {|
 # + consent - Consent status (optional)  
 # + createdDate - Date of creation
 # + exportSummary - Export summary payload (optional)
+# + bulkExportJobId - Bulk export job ID (optional)
 public type PayerDataExchangeRequest record {|
     string requestId?;
     string payerId;

--- a/bulk-export-client/records.bal
+++ b/bulk-export-client/records.bal
@@ -74,7 +74,7 @@ public type BulkExportClientConfig record {|
 public type OutputFile record {|
     string 'type;
     string url;
-    int count;
+    int count?;
 |};
 
 # record to hold summary of exports.
@@ -132,6 +132,7 @@ public type PayerDataExchangeRequest record {|
     string consent?;
     string createdDate?;
     string exportSummary?;
+    string bulkExportJobId?;
 |};
 
 # Record to hold payer data exchange request result with total count.

--- a/bulk-export-client/scripts/init_db.sql
+++ b/bulk-export-client/scripts/init_db.sql
@@ -14,6 +14,17 @@ CREATE TABLE IF NOT EXISTS payers (
   PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS bulk_export_jobs (
+    job_id                      VARCHAR(36) PRIMARY KEY,
+    payer_id                    VARCHAR(255) NOT NULL,
+    status                      VARCHAR(50) NOT NULL DEFAULT 'INITIATED',
+    created_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at                TIMESTAMP NULL,
+    FOREIGN KEY (payer_id) REFERENCES payers(id)
+);
+
+CREATE INDEX idx_bulk_export_jobs_status ON bulk_export_jobs(status);
+
 CREATE TABLE IF NOT EXISTS payer_data_exchange_requests (
     request_id VARCHAR(36) PRIMARY KEY,
     member_id VARCHAR(255) NOT NULL,
@@ -24,8 +35,10 @@ CREATE TABLE IF NOT EXISTS payer_data_exchange_requests (
     consent_status VARCHAR(50) DEFAULT 'PENDING',
     bulk_data_sync_status VARCHAR(50) DEFAULT 'PENDING',
     export_summary TEXT,
+    bulk_export_job_id VARCHAR(36) NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (payer_id) REFERENCES payers(id)
+    FOREIGN KEY (payer_id) REFERENCES payers(id),
+    FOREIGN KEY (bulk_export_job_id) REFERENCES bulk_export_jobs(job_id)
 );
 
 -- Create index on email for faster lookups

--- a/bulk-export-client/utils.bal
+++ b/bulk-export-client/utils.bal
@@ -240,7 +240,7 @@ public isolated function sendFileFromFSToFTP(TargetServerConfig config, string s
     });
     stream<io:Block, io:Error?> fileStream
         = check io:fileReadBlocksAsStream(sourcePath, 1024);
-    check fileClient->putBytesAsStream(string `${config.directory ?: ""}/${fileName}`, fileStream);
+    check fileClient->put(string `${config.directory ?: ""}/${fileName}`, fileStream);
     check fileStream.close();
 }
 

--- a/bulk-export-client/utils.bal
+++ b/bulk-export-client/utils.bal
@@ -240,7 +240,7 @@ public isolated function sendFileFromFSToFTP(TargetServerConfig config, string s
     });
     stream<io:Block, io:Error?> fileStream
         = check io:fileReadBlocksAsStream(sourcePath, 1024);
-    check fileClient->put(string `${config.directory ?: ""}/${fileName}`, fileStream);
+    check fileClient->putBytesAsStream(string `${config.directory ?: ""}/${fileName}`, fileStream);
     check fileStream.close();
 }
 


### PR DESCRIPTION
## Purpose

Implements the `$bulk-member-match` and `$davinci-data-export` async workflow in bulk-export-client for CMS-0057F payer-to-payer data exchange (PDex). Prior to this change, only single-member `$member-match` + individual bulk export was supported.

## Goals

- Expose a `/pdex/trigger-bulk-data-exchange` endpoint that batches multiple payer data exchange requests into a single `$bulk-member-match` call to the old payer
- Poll the old payer asynchronously for match results, then automatically kick off `$davinci-data-export` for matched members
- Sync exported FHIR data back to the local FHIR server and mark each request `COMPLETED`
- Expose a `/pdex/bulk-export-jobs/{jobId}` status endpoint for consumers to poll progress

## Approach

**Two-stage async polling:**

1. **Stage 1 — `BulkMatchPollingTask`**: After POSTing to `/Group/$bulk-member-match` (async, `Prefer: respond-async`), a recurring Ballerina task polls the `Content-Location` URL. On 200, it parses the `Parameters` response, correlates matched/non-matched/consent-constrained members back to request IDs, updates per-request statuses, and triggers Stage 2.

2. **Stage 2 — `DaVinciExportPollingTask`**: POSTs to `/Group/{matchedGroupId}/$davinci-data-export` (async), then polls the export manifest. On completion, syncs NDJSON resources to the local FHIR server via `syncDataToFhirServer` and marks all matched requests `COMPLETED`.

A new `bulk_export_jobs` database table tracks job-level state (`INITIATED` → `BULK_MATCH_POLLING` → `BULK_MATCH_COMPLETED` → `EXPORT_POLLING` → `SYNCING` → `COMPLETED`/`FAILED`).

## User stories

- As a new payer, I can submit a batch of member exchange requests in a single API call and poll for their completion status without managing individual member-match flows
- As an operator, I can monitor bulk job progress through a single status endpoint that shows both job-level and per-request statuses

## Documentation

Implementation of CMS-0057F PDex specification; refer to the [Da Vinci Payer Data Exchange IG](http://hl7.org/fhir/us/davinci-pdex).

