### PR TITLE
Upgrade bal version of Payer Portal BFF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hs_err_pid*
 replay_pid*
 
 .idea/
+.claude
 
 # maven target directories
 target
@@ -69,3 +70,6 @@ node_modules/
 **/.devcontainer.json
 **/.vite
 **/.ai
+
+#Claude
+CLAUDE.md

--- a/demo-backends/wso2_payer_portal_bff/Ballerina.toml
+++ b/demo-backends/wso2_payer_portal_bff/Ballerina.toml
@@ -3,7 +3,7 @@ org = "wso2"
 name = "wso2_payer_portal_bff"
 version = "0.1.0"
 title = "wso2-payer-portal-bff"
-distribution = "2201.12.7"
+distribution = "2201.12.10"
 
 [build-options]
 sticky = true

--- a/demo-backends/wso2_payer_portal_bff/Dependencies.toml
+++ b/demo-backends/wso2_payer_portal_bff/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.7"
+distribution-version = "2201.12.10"
 
 [[package]]
 org = "ballerina"


### PR DESCRIPTION
## Purpose
- This PR upgrades bal version to overcome the following bal issue during BFF building.

```
ERROR [wso2_payer_portal_bff:(1:1,1:1)] method is too large: '$process_annotations0'
```