### PR TITLE
Use the terminology service to retrieve review action codes during the claim approval process

### DIFF
--- a/apps/payer-admin-app/src/pages/PARequestDetail.tsx
+++ b/apps/payer-admin-app/src/pages/PARequestDetail.tsx
@@ -1592,7 +1592,7 @@ export default function PARequestDetail() {
                     {item.reviewActionCode && (
                       <Chip
                         icon={item.reviewActionCode === 'approved' ? <CheckCircle size={14} /> : <XCircle size={14} />}
-                        label={item.reviewActionCode ?? (item.reviewActionCode === 'approved' ? 'Approved' : 'Denied')}
+                        label={item.reviewActionCode === 'approved' ? 'Approved' : 'Denied'}
                         color={item.reviewActionCode === 'approved' ? 'success' : 'error'}
                         size="small"
                         sx={{ fontWeight: 600 }}

--- a/apps/payer-admin-app/src/pages/PARequestDetail.tsx
+++ b/apps/payer-admin-app/src/pages/PARequestDetail.tsx
@@ -1593,7 +1593,7 @@ export default function PARequestDetail() {
                     {item.reviewActionCode && (
                       <Chip
                         icon={item.reviewActionCode === 'approved' ? <CheckCircle size={14} /> : <XCircle size={14} />}
-                        label={item.reviewActionCode === 'approved' ? 'Approved' : 'Denied'}
+                        label={item.reviewActionDisplay ?? (item.reviewActionCode === 'approved' ? 'Approved' : 'Denied')}
                         color={item.reviewActionCode === 'approved' ? 'success' : 'error'}
                         size="small"
                         sx={{ fontWeight: 600 }}

--- a/apps/payer-admin-app/src/pages/PARequestDetail.tsx
+++ b/apps/payer-admin-app/src/pages/PARequestDetail.tsx
@@ -178,9 +178,8 @@ const extractReviewActionCode = (adjudication: unknown[]): 'approved' | 'denied'
       for (const nested of ext.extension || []) {
         if (nested.url === 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionCode') {
           const code = nested.valueCodeableConcept?.coding?.[0]?.code;
-          // Resolve these codes using the terminology service after fixing issue: https://github.com/wso2-enterprise/open-healthcare/issues/2108
-          if (code === 'A1') return 'approved';
-          if (code === 'A3') return 'denied';
+          if (code === 'approved') return 'approved';
+          if (code === 'denied') return 'denied';
         }
       }
     }
@@ -1593,7 +1592,7 @@ export default function PARequestDetail() {
                     {item.reviewActionCode && (
                       <Chip
                         icon={item.reviewActionCode === 'approved' ? <CheckCircle size={14} /> : <XCircle size={14} />}
-                        label={item.reviewActionDisplay ?? (item.reviewActionCode === 'approved' ? 'Approved' : 'Denied')}
+                        label={item.reviewActionCode ?? (item.reviewActionCode === 'approved' ? 'Approved' : 'Denied')}
                         color={item.reviewActionCode === 'approved' ? 'success' : 'error'}
                         size="small"
                         sx={{ fontWeight: 600 }}

--- a/apps/payer-admin-app/src/types/api.ts
+++ b/apps/payer-admin-app/src/types/api.ts
@@ -181,6 +181,7 @@ export interface ClaimItem {
   adjudication?: unknown[];
   noteNumbers?: number[];
   reviewNote?: string;
+  reviewActionDisplay?: string;
 }
 
 /**

--- a/demo-backends/wso2_payer_portal_bff/config.bal
+++ b/demo-backends/wso2_payer_portal_bff/config.bal
@@ -17,3 +17,6 @@
 configurable string base = ?;
 configurable string pdexBaseUrl = ?;
 configurable DatabaseConfig databaseConfig = ?;
+configurable string terminologyServiceUrl = ?;
+configurable string reviewActionCodeSystem = ?;
+configurable string? reviewActionCodeSystemVersion = ();

--- a/demo-backends/wso2_payer_portal_bff/connections.bal
+++ b/demo-backends/wso2_payer_portal_bff/connections.bal
@@ -28,3 +28,4 @@ final mysql:Client dbClient = check new (
 
 final http:Client fhirHttpClient = check new (base);
 final http:Client pdexHttpClient = check new (pdexBaseUrl);
+final http:Client terminologyHttpClient = check new (terminologyServiceUrl);

--- a/demo-backends/wso2_payer_portal_bff/pa_request_utils.bal
+++ b/demo-backends/wso2_payer_portal_bff/pa_request_utils.bal
@@ -956,6 +956,47 @@ isolated function parseClaimItems(international401:ClaimItem[] pasClaimItems, in
             }
         }
         
+        // Extract review action code from the DaVinci PAS extension and resolve its display
+        string? reviewActionDisplay = ();
+        if adjudication is json[] {
+            foreach json adj in adjudication {
+                if adj is map<json> {
+                    json extJson = adj["extension"];
+                    if extJson is json[] {
+                        foreach json ext in extJson {
+                            if ext is map<json> && ext["url"] == "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction" {
+                                json innerExts = ext["extension"];
+                                if innerExts is json[] {
+                                    foreach json innerExt in innerExts {
+                                        if innerExt is map<json> && innerExt["url"] == "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionCode" {
+                                            json valueConcept = innerExt["valueCodeableConcept"];
+                                            if valueConcept is map<json> {
+                                                json codings = valueConcept["coding"];
+                                                if codings is json[] && codings.length() > 0 {
+                                                    json firstCoding = codings[0];
+                                                    if firstCoding is map<json> {
+                                                        json code = firstCoding["code"];
+                                                        if code is string {
+                                                            reviewActionDisplay = lookupCodeSystemDisplay(code, reviewActionCodeSystem, reviewActionCodeSystemVersion);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+                if reviewActionDisplay is string {
+                    break;
+                }
+            }
+        }
+
         ClaimItem item = {
             sequence: pasItem.sequence,
             productOrService: productOrServiceJson,
@@ -967,7 +1008,8 @@ isolated function parseClaimItems(international401:ClaimItem[] pasClaimItems, in
             servicedPeriod: servicedPeriodJson,
             adjudication: adjudication,
             noteNumbers: noteNumbers,
-            reviewNote: reviewNote
+            reviewNote: reviewNote,
+            reviewActionDisplay: reviewActionDisplay
         };
         
         items.push(item);
@@ -1191,8 +1233,8 @@ public isolated function submitPARequestAdjudication(string responseId, Adjudica
 
         // Attach DaVinci PAS reviewAction extension to the primary adjudication entry
         if itemAdj.reviewActionCode is string {
-            string reviewCode = itemAdj.reviewActionCode == "approved" ? "A1" : "A3";
-            string reviewDisplay = itemAdj.reviewActionCode == "approved" ? "Certified in total" : "Not Certified";
+            string? reviewActionCode = itemAdj.reviewActionCode;
+            string? reviewDisplay = lookupCodeSystemDisplay(reviewActionCode, reviewActionCodeSystem, reviewActionCodeSystemVersion);
             mainAdj["extension"] = [
                 {
                     url: "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction",
@@ -1202,8 +1244,8 @@ public isolated function submitPARequestAdjudication(string responseId, Adjudica
                             valueCodeableConcept: {
                                 coding: [
                                     {
-                                        system: "https://codesystem.x12.org/005010/306",
-                                        code: reviewCode,
+                                        system: reviewActionCodeSystem,
+                                        code: reviewActionCode,
                                         display: reviewDisplay
                                     }
                                 ]

--- a/demo-backends/wso2_payer_portal_bff/pa_request_utils.bal
+++ b/demo-backends/wso2_payer_portal_bff/pa_request_utils.bal
@@ -1258,7 +1258,7 @@ public isolated function submitPARequestAdjudication(string responseId, Adjudica
         adjudicationArray.push(mainAdj);
 
         // Add benefit amount only for approved items; denied items carry no approved amount
-        if itemAdj.reviewActionCode != "denied" && itemAdj.approvedAmount is decimal {
+        if (itemAdj.reviewActionCode == "denied" || itemAdj.reviewActionCode == "approved") && itemAdj.approvedAmount is decimal {
             international401:ClaimResponseItemAdjudication benefitAdj = {
                 category: {
                     coding: [

--- a/demo-backends/wso2_payer_portal_bff/types.bal
+++ b/demo-backends/wso2_payer_portal_bff/types.bal
@@ -371,9 +371,10 @@ public type CoverageInformation record {
 # + net - field description  
 # + servicedDate - field description  
 # + servicedPeriod - field description  
-# + adjudication - field description  
-# + noteNumbers - field description  
+# + adjudication - field description
+# + noteNumbers - field description
 # + reviewNote - field description
+# + reviewActionDisplay - Human-readable display for the review action code, resolved from the terminology service
 public type ClaimItem record {
     int sequence;
     json productOrService; // FHIR CodeableConcept
@@ -386,6 +387,7 @@ public type ClaimItem record {
     json[]? adjudication;
     int[]? noteNumbers;
     string? reviewNote;
+    string? reviewActionDisplay;
 };
 
 # Patient Event Dates
@@ -483,7 +485,7 @@ public type ReviewActionCode "approved"|"denied";
 # + adjudicationCode - field description
 # + approvedAmount - field description
 # + itemNotes - field description
-# + reviewActionCode - DaVinci PAS review action: "approved" (A1 - Certified in total) or "denied" (A3 - Not Certified)
+# + reviewActionCode - DaVinci PAS review action: "approved" or "denied"
 public type ItemAdjudicationSubmission record {
     int sequence;
     string adjudicationCode; // "copay", "deductible", "benefit", etc.

--- a/demo-backends/wso2_payer_portal_bff/utils.bal
+++ b/demo-backends/wso2_payer_portal_bff/utils.bal
@@ -20,6 +20,41 @@ import ballerina/lang.regexp;
 import ballerina/http;
 import ballerina/jwt;
 
+# Look up the display string for a code in a given CodeSystem via the terminology service.
+# Returns () on any error or if the display parameter is absent in the response.
+#
+# + code - The code to look up
+# + system - CodeSystem canonical URL
+# + version - CodeSystem version (omitted from request if not provided)
+# + return - Display string or () if unavailable
+isolated function lookupCodeSystemDisplay(string? code, string system, string? version) returns string? {
+    
+    if code is string {
+        string path = version is string
+            ? string `/CodeSystem/%24lookup?system=${system}&code=${code}&version=${version}`
+            : string `/CodeSystem/%24lookup?system=${system}&code=${code}`;
+        json|http:ClientError result = terminologyHttpClient->get(path);
+        if result is http:ClientError {
+            log:printWarn("Terminology lookup failed for code " + code + ": " + result.message());
+            return ();
+        }
+        if result is map<json> {
+            json params = result["parameter"];
+            if params is json[] {
+                foreach json param in params {
+                    if param is map<json> && param["name"] == "display" {
+                        json display = param["valueString"];
+                        if display is string {
+                            return display;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return ();
+}
+
 isolated function AddDurationToDate(string date, string durationDays) returns string|error {
     // Parse the duration days
     int days = check int:fromString(durationDays);

--- a/fhir-service/Dependencies.toml
+++ b/fhir-service/Dependencies.toml
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/fhir-service/Dependencies.toml
+++ b/fhir-service/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -77,7 +77,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -382,7 +382,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -625,7 +625,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhirr4"
-version = "3.0.6"
+version = "3.0.8"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},

--- a/fhir-service/records.bal
+++ b/fhir-service/records.bal
@@ -767,14 +767,14 @@ final int STANDARD = 1;
 final int EXPEDITED = 2;
 
 // Claim statuses
-final int APPROVED = 3;
-final int PARTIALLY_APPROVED = 4;
-final int DENIED = 5;
+final int APPROVED_STATUS = 3;
+final int PARTIALLY_APPROVED_STATUS = 4;
+final int DENIED_STATUS = 5;
 
-public enum X12ReviewActionCodes {
-    A1 = "A1", // Approved
-    A2 = "A2", // Partially Approved
-    A3 = "A3" // Denied
+public enum ClaimResponseDecisionCodes {
+    APPROVED = "approved",
+    PARTIALLY_APPROVED = "partially_approved",
+    DENIED = "denied"
 }
 
 public enum ClaimResponseOutcome {

--- a/fhir-service/utils.bal
+++ b/fhir-service/utils.bal
@@ -1448,6 +1448,8 @@ isolated function determineClaimType(ClaimResponse claimResponse, international4
 # 2. "denied" if all items are denied. 
 # 3. "partially-approved" if a subset of items are approved. 
 # 
+# It is assumed that an item can contain only one adjudication with the reviewAction extension.
+# 
 # NOTE: If there are no items present in a completed claim, 
 # * If a "preAuthRef" is present in claim response, it is assumed that the claim is approved without needing to review items.
 # * If a "preAuthRef" is not present, it is assumed that the claim is rejected.

--- a/fhir-service/utils.bal
+++ b/fhir-service/utils.bal
@@ -1481,13 +1481,13 @@ isolated function determineClaimStatus(ClaimResponse claimResponse) returns int 
                 log:printDebug(string `Number of items: ${numberOfItems}`);
                 log:printDebug(string `Number of approved adjudications: ${numberOfApprovedAdjudications}`);
                 log:printDebug(string `Aggregated status: Approved`);
-                return APPROVED;
+                return APPROVED_STATUS;
             }
             // When there are no items present in a "completed" claim, this can mean the request is rejected.
             log:printDebug(string `Number of items: ${numberOfItems}`);
             log:printDebug(string `Number of approved adjudications: ${numberOfApprovedAdjudications}`);
             log:printDebug(string `Aggregated status: Denied`);
-            return DENIED;
+            return DENIED_STATUS;
         }
 
         foreach davincipas:PASClaimResponseItem item in items {
@@ -1516,7 +1516,7 @@ isolated function determineClaimStatus(ClaimResponse claimResponse) returns int 
                                                 if reviewActionCodings is r4:Coding[] {
                                                     foreach r4:Coding reviewActionCoding in reviewActionCodings {
                                                         r4:code? code = reviewActionCoding.code;
-                                                        if code is string && code == A1 {
+                                                        if code is string && code.toLowerAscii() == APPROVED {
                                                                 numberOfApprovedAdjudications += 1;
                                                         }
                                                     }
@@ -1535,15 +1535,15 @@ isolated function determineClaimStatus(ClaimResponse claimResponse) returns int 
         log:printDebug(string `Number of approved adjudications: ${numberOfApprovedAdjudications}`);
         if numberOfItems == numberOfApprovedAdjudications {
             log:printDebug(string `Aggregated status: Approved`);
-            return APPROVED;
+            return APPROVED_STATUS;
         }
         if numberOfApprovedAdjudications == 0 {
             log:printDebug(string `Aggregated status: Denied`);
-            return DENIED;
+            return DENIED_STATUS;
         }
         if numberOfItems > numberOfApprovedAdjudications {
             log:printDebug(string `Aggregated status: Partially Approved`);
-            return PARTIALLY_APPROVED;
+            return PARTIALLY_APPROVED_STATUS;
         }
     }
     // When a completed claim doesn't have items, if a "preAuthRef" is present, this can mean the whole 
@@ -1552,11 +1552,11 @@ isolated function determineClaimStatus(ClaimResponse claimResponse) returns int 
         log:printDebug(string `Number of items: ${numberOfItems}`);
         log:printDebug(string `Number of approved adjudications: ${numberOfApprovedAdjudications}`);
         log:printDebug(string `Aggregated status: Approved`);
-        return APPROVED;
+        return APPROVED_STATUS;
     }
     log:printDebug(string `Number of items: ${numberOfItems}`);
     log:printDebug(string `Number of approved adjudications: ${numberOfApprovedAdjudications}`);
     // When there are no items present in a "completed" claim, this can mean the request is rejected.
     log:printDebug(string `Aggregated status: Denied`);
-    return DENIED;
+    return DENIED_STATUS;
 }


### PR DESCRIPTION
## Use the terminology service to retrieve review action codes during the claim approval process

- Adds the terminology service integration to the BFF
- $lookup function is used to lookup the relevant reviewActionCode based on the drop-down selection in the payer admin portal UI.

- **Issue**: https://github.com/wso2-enterprise/open-healthcare/issues/2129

